### PR TITLE
GitHub Actions workflow building MinGW toolchain

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,23 +1,469 @@
 name: Build MinGW and MSYS2 toolchain
 
 on:
-    workflow_dispatch:
-      inputs:
-        msys2_packages_branch:
-          description: 'MSYS2-packages branch to build'
-          required: false
-          default: 'woarm64'
+  workflow_dispatch:
+    inputs:
+      msys2_packages_branch:
+        description: "MSYS2-packages branch to build"
+        type: string
+        required: false
+        default: "woarm64"
+
+defaults:
+  run:
+    shell: msys2 {0}
+
+env:
+  MSYS2_REPO: Windows-on-ARM-Experiments/MSYS2-packages
 
 jobs:
-    mingw-w64-cross-headers:
-        runs-on: windows-latest
-        
-        steps:
-            - name: Checkout MSYS2 packages repository
-              uses: actions/checkout@v4
-              with:
-                repository: Windows-on-ARM-Experiments/MSYS2-packages
-                ref: ${{ github.event.inputs.msys2_packages_branch }}
+  mingw-w64-cross-headers:
+    runs-on: [Windows, X64, self-hosted]
 
-            - name: Test
-              run: echo "Hello World!"
+    steps:
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MSYS
+          location: ${{ github.workspace }}
+          release: true
+          update: true
+          cache: false
+          install: base-devel
+
+      - name: Checkout MSYS2 packages repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.MSYS2_REPO }}
+          ref: ${{ github.event.inputs.msys2_packages_branch }}
+          path: ${{ github.workspace }}/MSYS2-packages
+
+      - name: Build mingw-w64-cross-headers
+        working-directory: ${{ github.workspace }}/MSYS2-packages/mingw-w64-cross-headers
+        run: makepkg --syncdeps --rmdeps --cleanbuild --noconfirm --noprogressbar --force
+
+      - name: Upload mingw-w64-cross-headers
+        uses: actions/upload-artifact@v3
+        with:
+          name: mingw-w64-cross-headers
+          retention-days: 1
+          path: ${{ github.workspace }}/MSYS2-packages/mingw-w64-cross-headers/*.pkg.tar.zst
+
+  mingw-w64-cross-binutils:
+    needs: [mingw-w64-cross-headers]
+    runs-on: [Windows, X64, self-hosted]
+
+    steps:
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MSYS
+          location: ${{ github.workspace }}
+          release: true
+          update: true
+          cache: false
+          install: base-devel
+
+      - name: Checkout MSYS2 packages repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.MSYS2_REPO }}
+          ref: ${{ github.event.inputs.msys2_packages_branch }}
+          path: ${{ github.workspace }}/MSYS2-packages
+
+      - name: Download mingw-w64-cross-headers
+        uses: actions/download-artifact@v3
+        with:
+          name: mingw-w64-cross-headers
+
+      - name: Install artifacts
+        run: pacman -U --noconfirm *.pkg.tar.zst
+
+      - name: Build mingw-w64-cross-binutils
+        working-directory: ${{ github.workspace }}/MSYS2-packages/mingw-w64-cross-binutils
+        run: makepkg --syncdeps --rmdeps --cleanbuild --noconfirm --noprogressbar --nocheck --force
+
+      - name: Upload mingw-w64-cross-binutils
+        uses: actions/upload-artifact@v3
+        with:
+          name: mingw-w64-cross-binutils
+          retention-days: 1
+          path: ${{ github.workspace }}/MSYS2-packages/mingw-w64-cross-binutils/*.pkg.tar.zst
+
+  mingw-w64-cross-gcc-stage1:
+    needs: [mingw-w64-cross-headers, mingw-w64-cross-binutils]
+    runs-on: [Windows, X64, self-hosted]
+
+    steps:
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MSYS
+          location: ${{ github.workspace }}
+          release: true
+          update: true
+          cache: false
+          install: base-devel
+
+      - name: Checkout MSYS2 packages repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.MSYS2_REPO }}
+          ref: ${{ github.event.inputs.msys2_packages_branch }}
+          path: ${{ github.workspace }}/MSYS2-packages
+
+      - name: Download mingw-w64-cross-headers
+        uses: actions/download-artifact@v3
+        with:
+          name: mingw-w64-cross-headers
+
+      - name: Download mingw-w64-cross-binutils
+        uses: actions/download-artifact@v3
+        with:
+          name: mingw-w64-cross-binutils
+
+      - name: Install artifacts
+        run: pacman -U --noconfirm *.pkg.tar.zst
+
+      - name: Build mingw-w64-cross-gcc-stage1
+        working-directory: ${{ github.workspace }}/MSYS2-packages/mingw-w64-cross-gcc-stage1
+        run: makepkg --syncdeps --rmdeps --cleanbuild --noconfirm --noprogressbar --force
+
+      - name: Upload mingw-w64-cross-gcc-stage1
+        uses: actions/upload-artifact@v3
+        with:
+          name: mingw-w64-cross-gcc-stage1
+          retention-days: 1
+          path: ${{ github.workspace }}/MSYS2-packages/mingw-w64-cross-gcc-stage1/*.pkg.tar.zst
+
+  mingw-w64-cross-windows-default-manifest:
+    needs: [mingw-w64-cross-binutils, mingw-w64-cross-gcc-stage1]
+    runs-on: [Windows, X64, self-hosted]
+
+    steps:
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MSYS
+          location: ${{ github.workspace }}
+          release: true
+          update: true
+          cache: false
+          install: base-devel
+
+      - name: Checkout MSYS2 packages repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.MSYS2_REPO }}
+          ref: ${{ github.event.inputs.msys2_packages_branch }}
+          path: ${{ github.workspace }}/MSYS2-packages
+
+      - name: Download mingw-w64-cross-binutils
+        uses: actions/download-artifact@v3
+        with:
+          name: mingw-w64-cross-binutils
+
+      - name: Download mingw-w64-cross-gcc-stage1
+        uses: actions/download-artifact@v3
+        with:
+          name: mingw-w64-cross-gcc-stage1
+
+      - name: Install artifacts
+        run: pacman -U --noconfirm *.pkg.tar.zst
+
+      - name: Build mingw-w64-cross-windows-default-manifest
+        working-directory: ${{ github.workspace }}/MSYS2-packages/mingw-w64-cross-windows-default-manifest
+        run: makepkg --syncdeps --rmdeps --cleanbuild --noconfirm --noprogressbar --force
+
+      - name: Upload mingw-w64-cross-windows-default-manifest
+        uses: actions/upload-artifact@v3
+        with:
+          name: mingw-w64-cross-windows-default-manifest
+          retention-days: 1
+          path: ${{ github.workspace }}/MSYS2-packages/mingw-w64-cross-windows-default-manifest/*.pkg.tar.zst
+
+  mingw-w64-cross-crt:
+    needs:
+      [
+        mingw-w64-cross-headers,
+        mingw-w64-cross-binutils,
+        mingw-w64-cross-gcc-stage1,
+      ]
+    runs-on: [Windows, X64, self-hosted]
+
+    steps:
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MSYS
+          location: ${{ github.workspace }}
+          release: true
+          update: true
+          cache: false
+          install: >-
+            base-devel
+            mingw-w64-cross-winpthreads
+
+      - name: Checkout MSYS2 packages repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.MSYS2_REPO }}
+          ref: ${{ github.event.inputs.msys2_packages_branch }}
+          path: ${{ github.workspace }}/MSYS2-packages
+
+      - name: Download mingw-w64-cross-headers
+        uses: actions/download-artifact@v3
+        with:
+          name: mingw-w64-cross-headers
+
+      - name: Download mingw-w64-cross-binutils
+        uses: actions/download-artifact@v3
+        with:
+          name: mingw-w64-cross-binutils
+
+      - name: Download mingw-w64-cross-gcc-stage1
+        uses: actions/download-artifact@v3
+        with:
+          name: mingw-w64-cross-gcc-stage1
+
+      - name: Install artifacts
+        run: pacman -U --noconfirm *.pkg.tar.zst
+
+      - name: Copy missing headers
+        run: |
+          cp /opt/x86_64-w64-mingw32/include/pthread_signal.h /opt/aarch64-w64-mingw32/include/
+          cp /opt/x86_64-w64-mingw32/include/pthread_unistd.h /opt/aarch64-w64-mingw32/include/
+          cp /opt/x86_64-w64-mingw32/include/pthread_time.h /opt/aarch64-w64-mingw32/include/
+
+      - name: Build mingw-w64-cross-crt
+        working-directory: ${{ github.workspace }}/MSYS2-packages/mingw-w64-cross-crt
+        run: makepkg --syncdeps --rmdeps --cleanbuild --noconfirm --noprogressbar --force
+
+      - name: Upload mingw-w64-cross-crt
+        uses: actions/upload-artifact@v3
+        with:
+          name: mingw-w64-cross-crt
+          retention-days: 1
+          path: ${{ github.workspace }}/MSYS2-packages/mingw-w64-cross-crt/*.pkg.tar.zst
+
+  mingw-w64-cross-winpthreads:
+    needs:
+      [
+        mingw-w64-cross-headers,
+        mingw-w64-cross-binutils,
+        mingw-w64-cross-gcc-stage1,
+        mingw-w64-cross-crt,
+      ]
+    runs-on: [Windows, X64, self-hosted]
+
+    steps:
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MSYS
+          location: ${{ github.workspace }}
+          release: true
+          update: true
+          cache: false
+          install: base-devel
+
+      - name: Checkout MSYS2 packages repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.MSYS2_REPO }}
+          ref: ${{ github.event.inputs.msys2_packages_branch }}
+          path: ${{ github.workspace }}/MSYS2-packages
+
+      - name: Download mingw-w64-cross-headers
+        uses: actions/download-artifact@v3
+        with:
+          name: mingw-w64-cross-headers
+
+      - name: Download mingw-w64-cross-binutils
+        uses: actions/download-artifact@v3
+        with:
+          name: mingw-w64-cross-binutils
+
+      - name: Download mingw-w64-cross-gcc-stage1
+        uses: actions/download-artifact@v3
+        with:
+          name: mingw-w64-cross-gcc-stage1
+
+      - name: Download mingw-w64-cross-crt
+        uses: actions/download-artifact@v3
+        with:
+          name: mingw-w64-cross-crt
+
+      - name: Install artifacts
+        run: pacman -U --noconfirm *.pkg.tar.zst
+
+      - name: Build mingw-w64-cross-winpthreads
+        working-directory: ${{ github.workspace }}/MSYS2-packages/mingw-w64-cross-winpthreads
+        run: makepkg --syncdeps --rmdeps --cleanbuild --noconfirm --noprogressbar --force
+
+      - name: Upload mingw-w64-cross-winpthreads
+        uses: actions/upload-artifact@v3
+        with:
+          name: mingw-w64-cross-winpthreads
+          retention-days: 1
+          path: ${{ github.workspace }}/MSYS2-packages/mingw-w64-cross-winpthreads/*.pkg.tar.zst
+
+  mingw-w64-cross-gcc:
+    needs:
+      [
+        mingw-w64-cross-headers,
+        mingw-w64-cross-binutils,
+        mingw-w64-cross-windows-default-manifest,
+        mingw-w64-cross-crt,
+        mingw-w64-cross-winpthreads,
+      ]
+    runs-on: [Windows, X64, self-hosted]
+
+    steps:
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MSYS
+          location: ${{ github.workspace }}
+          release: true
+          update: true
+          cache: false
+          install: base-devel
+
+      - name: Checkout MSYS2 packages repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.MSYS2_REPO }}
+          ref: ${{ github.event.inputs.msys2_packages_branch }}
+          path: ${{ github.workspace }}/MSYS2-packages
+
+      - name: Download mingw-w64-cross-headers
+        uses: actions/download-artifact@v3
+        with:
+          name: mingw-w64-cross-headers
+
+      - name: Download mingw-w64-cross-binutils
+        uses: actions/download-artifact@v3
+        with:
+          name: mingw-w64-cross-binutils
+
+      - name: Download mingw-w64-cross-windows-default-manifest
+        uses: actions/download-artifact@v3
+        with:
+          name: mingw-w64-cross-windows-default-manifest
+
+      - name: Download mingw-w64-cross-crt
+        uses: actions/download-artifact@v3
+        with:
+          name: mingw-w64-cross-crt
+
+      - name: Download mingw-w64-cross-winpthreads
+        uses: actions/download-artifact@v3
+        with:
+          name: mingw-w64-cross-winpthreads
+
+      - name: Install artifacts
+        run: pacman -U --noconfirm *.pkg.tar.zst
+
+      - name: Build mingw-w64-cross-gcc
+        working-directory: ${{ github.workspace }}/MSYS2-packages/mingw-w64-cross-gcc
+        run: makepkg --syncdeps --rmdeps --cleanbuild --noconfirm --noprogressbar --force
+
+      - name: Upload mingw-w64-cross-gcc
+        uses: actions/upload-artifact@v3
+        with:
+          name: mingw-w64-cross-gcc
+          retention-days: 1
+          path: ${{ github.workspace }}/MSYS2-packages/mingw-w64-cross-gcc/*.pkg.tar.zst
+
+  repository:
+    needs:
+      [
+        mingw-w64-cross-headers,
+        mingw-w64-cross-binutils,
+        mingw-w64-cross-gcc-stage1,
+        mingw-w64-cross-windows-default-manifest,
+        mingw-w64-cross-crt,
+        mingw-w64-cross-winpthreads,
+        mingw-w64-cross-gcc,
+      ]
+    runs-on: windows-latest
+
+    steps:
+      - uses: msys2/setup-msys2@v2
+
+      - name: Download mingw-w64-cross-headers
+        uses: actions/download-artifact@v3
+        with:
+          name: mingw-w64-cross-headers
+
+      - name: Download mingw-w64-cross-binutils
+        uses: actions/download-artifact@v3
+        with:
+          name: mingw-w64-cross-binutils
+
+      - name: Download mingw-w64-cross-gcc-stage1
+        uses: actions/download-artifact@v3
+        with:
+          name: mingw-w64-cross-gcc-stage1
+
+      - name: Download mingw-w64-cross-windows-default-manifest
+        uses: actions/download-artifact@v3
+        with:
+          name: mingw-w64-cross-windows-default-manifest
+
+      - name: Download mingw-w64-cross-crt
+        uses: actions/download-artifact@v3
+        with:
+          name: mingw-w64-cross-crt
+
+      - name: Download mingw-w64-cross-winpthreads
+        uses: actions/download-artifact@v3
+        with:
+          name: mingw-w64-cross-winpthreads
+
+      - name: Download mingw-w64-cross-gcc
+        uses: actions/download-artifact@v3
+        with:
+          name: mingw-w64-cross-gcc
+
+      - name: Setup MSYS2 packages repository
+        run: |
+          mkdir aarch64
+          mkdir x86_64
+
+          mv -f *-x86_64.pkg.tar.zst x86_64/
+
+          cd x86_64
+          repo-add woarm64.db.tar.gz *.pkg.tar.zst
+
+      - name: Create index.html
+        run: |
+          echo "<!DOCTYPE html><head></head><body></body>" > index.html
+
+      - name: Upload woarm64-msys2-repository
+        uses: actions/upload-pages-artifact@v2
+        with:
+          name: woarm64-msys2-repository
+          retention-days: 1
+          path: "."
+
+  deploy:
+    needs: [repository]
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{steps.deployment.outputs.page_url}}
+
+    defaults:
+      run:
+        shell: bash {0}
+
+    steps:
+      - name: Setup GitHub Pages
+        uses: actions/configure-pages@v3
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2
+        with:
+          artifact_name: woarm64-msys2-repository

--- a/README.md
+++ b/README.md
@@ -1,0 +1,483 @@
+# MSYS2 WoArm64 Packages Build and Repository
+
+This repository contains GitHub Actions workflows for building MinGW and MSYS2 toolchains
+with `aarch64-w64-mingw32` and `aarch64-pc-msys` targets inside MSYS2 environment and as deploys
+their Pacman packages repository overlay to GitHub Pages environment of this repository. It also
+serves as a documentation of the necessary steps to build them.
+
+The MSYS2 packages recipes dwells in
+[Windows-on-ARM-Experiments/MSYS2-packages](https://github.com/Windows-on-ARM-Experiments/MSYS2-packages)
+repository. Please report any issue related to packages build to this repository's issues though.
+The actual GCC, binutils, and MinGW source code with the necessary `aarch64-w64-mingw32` target
+changes are located at [ZacWalk/gcc-woarm64](https://github.com/ZacWalk/gcc-woarm64),
+[ZacWalk/binutils-woarm64](https://github.com/ZacWalk/binutils-woarm64),
+and [ZacWalk/mingw-woarm64](https://github.com/ZacWalk/mingw-woarm64), resp. Please report
+any issues related to outputs of the toolchain binaries to
+[ZacWalk/mingw-woarm64-build](https://github.com/ZacWalk/mingw-woarm64-build) repository's issues
+though.
+
+## Packages Repository Usage
+
+Add the following to the `/etc/pacman.conf` before any other package repository specification:
+
+```ini
+[woarm64]
+Server = https://windows-on-arm-experiments.github.io/msys2-woarm64-build/$arch
+SigLevel = Optional
+```
+
+Run:
+
+```bash
+pacman -Sy
+```
+
+to update packages definitions.
+
+Run:
+
+```bash
+pacman -S mingw-w64-cross-gcc
+```
+
+to install x64 host MinGW compiler with `aarch64-w64-mingw32` target support.
+
+## Dependencies Chart
+
+The color of the blocks indicates whether the package recipes exist and/or succeed to build
+and install. It does not reflect whether they actually work or do not contain severe bugs
+to resolve.
+
+```mermaid
+%%{init: {"flowchart": {"htmlLabels": false, 'nodeSpacing': 30, 'rankSpacing': 30}} }%%
+flowchart LR
+    classDef EXIST fill:#888,color:#000,stroke:#000
+    classDef DONE fill:#3c3,color:#000,stroke:#000
+    classDef NEW_DONE fill:#3c3,color:#000,stroke:#f00,stroke-width:2,stroke-dasharray:5
+    classDef WIP fill:#cc3,color:#000,stroke:#000
+    classDef NEW_WIP fill:#cc3,color:#000,stroke:#f00,stroke-width:2,stroke-dasharray:5
+    classDef TODO fill:#c33,color:#000,stroke:#000
+    classDef NEW_TODO fill:#c33,color:#000,stroke:#f00,stroke-width:2,stroke-dasharray:5
+    classDef NEW fill:#fff,color:#000,stroke:#f00,stroke-width:2,stroke-dasharray:5
+
+    subgraph Legend
+      direction LR 
+      EXIST:::EXIST ~~~ TODO:::TODO ~~~ WIP:::WIP ~~~ DONE:::DONE ~~~  NEW:::NEW
+    end
+
+    binutils["`
+        binutils
+        host: x86_64-pc-msys
+        target: x86_64-pc-msys
+    `"]:::EXIST
+
+    gcc["`
+        gcc
+        host: x86_64-pc-msys
+        target: x86_64-pc-msys
+    `"]:::EXIST
+
+    msys2-runtime-devel["`
+        msys2-runtime-devel
+        host: x86_64-pc-msys
+        target: aarch64-pc-msys
+    `"]:::DONE
+
+    mingw-w64-cross-binutils["`
+        mingw-w64-cross-binutils
+        host: x86_64-pc-msys
+        target: aarch64-w64-mingw32
+    `"]:::DONE
+    
+    mingw-w64-cross-gcc["`
+        mingw-w64-cross-gcc
+        host: x86_64-pc-msys
+        target: aarch64-w64-mingw32
+    `"]:::DONE
+
+    mingw-w64-cross-gcc-stage1["`
+        mingw-w64-cross-gcc-stage1
+        host: x86_64-pc-msys
+        target: aarch64-w64-mingw32
+    `"]:::DONE
+
+    mingw-w64-cross-crt["`
+        mingw-w64-cross-crt
+        host: aarch64-w64-mingw32
+    `"]:::DONE
+
+    mingw-w64-cross-headers["`
+        mingw-w64-cross-headers
+        host: aarch64-w64-mingw32
+    `"]:::DONE
+
+    mingw-w64-cross-winpthreads["`
+        mingw-w64-cross-winpthreads
+        host: aarch64-w64-mingw32
+    `"]:::DONE
+
+    mingw-w64-cross-windows-default-manifest["`
+        mingw-w64-cross-windows-default-manifest
+        host: aarch64-w64-mingw32
+    `"]:::DONE
+
+    mingw-w64-cross-zlib["`
+        mingw-w64-cross-zlib
+        host: aarch64-w64-mingw32
+    `"]:::DONE
+
+    msys2-w32api-headers["`
+        msys2-w32api-headers
+        host: aarch64-pc-msys
+    `"]:::DONE
+
+    msys2-w32api-runtime["`
+        msys2-w32api-runtime
+        host: x86_64-pc-msys
+    `"]:::DONE
+
+    cross-binutils["`
+        cross-binutils
+        host: x86_64-pc-msys
+        target: aarch64-pc-msys
+    `"]:::DONE
+
+    cross-gcc-stage1["`
+        cross-gcc-stage1
+        host: x86_64-pc-msys
+        target: aarch64-pc-msys
+    `"]:::DONE
+
+    cross-gcc["`
+        cross-gcc
+        host: x86_64-pc-msys
+        target: aarch64-pc-msys
+    `"]:::WIP
+
+    windows-default-manifest["`
+        windows-default-manifest
+        host: aarch64-pc-msys
+    `"]:::DONE
+
+    msys2-runtime["`
+        msys2-runtime
+        host: aarch64-pc-msys
+    `"]:::WIP
+
+    bash["`
+       bash
+       host: aarch64-w64-mingw32 
+    `"]:::TODO
+
+    git4win["`
+       Git for Windows
+       host: aarch64-w64-mingw32 
+    `"]:::TODO
+
+    subgraph Bootstrap
+        direction TB
+        binutils --> gcc
+    end
+    
+    subgraph MinGW
+        subgraph Stage 1
+            gcc --> mingw-w64-cross-binutils
+
+            gcc --> mingw-w64-cross-gcc-stage1
+            mingw-w64-cross-binutils --> mingw-w64-cross-gcc-stage1
+            mingw-w64-cross-headers --> mingw-w64-cross-gcc-stage1
+        end
+
+        subgraph Stage 2\nDependencies
+            mingw-w64-cross-gcc-stage1 --> mingw-w64-cross-crt
+            mingw-w64-cross-binutils --> mingw-w64-cross-crt
+            mingw-w64-cross-headers --> mingw-w64-cross-crt
+            
+            mingw-w64-cross-gcc-stage1 --> mingw-w64-cross-winpthreads
+            mingw-w64-cross-binutils --> mingw-w64-cross-winpthreads
+            mingw-w64-cross-crt --> mingw-w64-cross-winpthreads
+            mingw-w64-cross-headers --> mingw-w64-cross-winpthreads
+
+            mingw-w64-cross-gcc-stage1 --> mingw-w64-cross-windows-default-manifest
+            mingw-w64-cross-binutils --> mingw-w64-cross-windows-default-manifest
+        end
+
+        subgraph Stage 2
+            gcc --> mingw-w64-cross-gcc
+            mingw-w64-cross-binutils --> mingw-w64-cross-gcc
+            mingw-w64-cross-crt --> mingw-w64-cross-gcc
+            mingw-w64-cross-headers --> mingw-w64-cross-gcc
+            mingw-w64-cross-winpthreads --> mingw-w64-cross-gcc
+            mingw-w64-cross-windows-default-manifest --> mingw-w64-cross-gcc
+
+        end
+
+        mingw-w64-cross-gcc --> mingw-w64-cross-zlib 
+    end
+
+    subgraph MSYS2
+        subgraph Stage 1
+             gcc --> msys2-runtime-devel
+
+             gcc --> cross-binutils
+
+             cross-binutils --> cross-gcc-stage1
+             gcc --> cross-gcc-stage1
+             msys2-runtime-devel --> cross-gcc-stage1
+             msys2-w32api-headers --> cross-gcc-stage1
+        end
+
+        subgraph Stage 2 Dependencies
+            mingw-w64-cross-gcc --> msys2-w32api-runtime 
+            msys2-w32api-headers --> msys2-w32api-runtime 
+
+            cross-gcc-stage1 --> windows-default-manifest
+        end
+
+        subgraph Stage 2
+            cross-gcc-stage1 --> cross-gcc
+            msys2-w32api-runtime --> cross-gcc
+            windows-default-manifest --> cross-gcc
+        end
+
+        subgraph Application\nDependencies
+            cross-gcc --> msys2-runtime
+            mingw-w64-cross-gcc --> msys2-runtime
+            mingw-w64-cross-crt --> msys2-runtime
+            mingw-w64-cross-zlib --> msys2-runtime
+        end
+
+        subgraph Application
+            cross-gcc --> bash
+            msys2-runtime --> bash
+
+            cross-gcc --> git4win
+            msys2-runtime --> git4win
+            bash --> git4win
+        end
+    end
+```
+
+## MingGW Toolchain CI
+
+```mermaid
+%%{init: {"flowchart": {"htmlLabels": false, 'nodeSpacing': 30, 'rankSpacing': 30}} }%%
+flowchart LR
+    classDef EXIST fill:#888,color:#000,stroke:#000
+    classDef DONE fill:#3c3,color:#000,stroke:#000
+    classDef NEW_DONE fill:#3c3,color:#000,stroke:#f00,stroke-width:2,stroke-dasharray:5
+    classDef WIP fill:#cc3,color:#000,stroke:#000
+    classDef NEW_WIP fill:#cc3,color:#000,stroke:#f00,stroke-width:2,stroke-dasharray:5
+    classDef TODO fill:#c33,color:#000,stroke:#000
+    classDef NEW_TODO fill:#c33,color:#000,stroke:#f00,stroke-width:2,stroke-dasharray:5
+    classDef NEW fill:#fff,color:#000,stroke:#f00,stroke-width:2,stroke-dasharray:5
+
+    subgraph Legend
+      direction LR 
+      EXIST:::EXIST ~~~ TODO:::TODO ~~~ WIP:::WIP ~~~ DONE:::DONE ~~~ NEW:::NEW
+    end
+
+    mingw-w64-cross-binutils["`
+        mingw-w64-cross-binutils
+        host: x86_64-pc-msys
+        target: aarch64-w64-mingw32
+    `"]:::DONE
+    
+    mingw-w64-cross-gcc["`
+        mingw-w64-cross-gcc
+        host: x86_64-pc-msys
+        target: aarch64-w64-mingw32
+    `"]:::DONE
+
+    mingw-w64-cross-gcc-stage1["`
+        mingw-w64-cross-gcc-stage1
+        host: x86_64-pc-msys
+        target: aarch64-w64-mingw32
+    `"]:::DONE
+
+    mingw-w64-cross-crt["`
+        mingw-w64-cross-crt
+        host: aarch64-w64-mingw32
+    `"]:::DONE
+
+    mingw-w64-cross-headers["`
+        mingw-w64-cross-headers
+        host: aarch64-w64-mingw32
+    `"]:::DONE
+
+    mingw-w64-cross-winpthreads["`
+        mingw-w64-cross-winpthreads
+        host: aarch64-w64-mingw32
+    `"]:::DONE
+
+    mingw-w64-cross-windows-default-manifest["`
+        mingw-w64-cross-windows-default-manifest
+        host: aarch64-w64-mingw32
+    `"]:::DONE
+
+    mingw-w64-cross-zlib["`
+        mingw-w64-cross-zlib
+        host: aarch64-w64-mingw32
+    `"]:::TODO
+
+    subgraph Stage 1
+        mingw-w64-cross-binutils --> mingw-w64-cross-gcc-stage1
+        mingw-w64-cross-headers --> mingw-w64-cross-gcc-stage1
+    end
+
+    subgraph Stage 2\nDependencies
+        mingw-w64-cross-gcc-stage1 --> mingw-w64-cross-crt
+        mingw-w64-cross-binutils --> mingw-w64-cross-crt
+        mingw-w64-cross-headers --> mingw-w64-cross-crt
+        
+        mingw-w64-cross-gcc-stage1 --> mingw-w64-cross-winpthreads
+        mingw-w64-cross-binutils --> mingw-w64-cross-winpthreads
+        mingw-w64-cross-crt --> mingw-w64-cross-winpthreads
+        mingw-w64-cross-headers --> mingw-w64-cross-winpthreads
+
+        mingw-w64-cross-gcc-stage1 --> mingw-w64-cross-windows-default-manifest
+        mingw-w64-cross-binutils --> mingw-w64-cross-windows-default-manifest
+    end
+
+    subgraph Stage 2
+        mingw-w64-cross-binutils --> mingw-w64-cross-gcc
+        mingw-w64-cross-crt --> mingw-w64-cross-gcc
+        mingw-w64-cross-headers --> mingw-w64-cross-gcc
+        mingw-w64-cross-winpthreads --> mingw-w64-cross-gcc
+        mingw-w64-cross-windows-default-manifest --> mingw-w64-cross-gcc
+    end
+
+    subgraph Software
+       mingw-w64-cross-gcc --> mingw-w64-cross-zlib 
+    end  
+```
+
+## MSYS2 Toolchain CI
+
+TODO
+
+## MSYS2/Cygwin Toolchain Porting
+
+```mermaid
+%%{init: {"flowchart": {"htmlLabels": false, 'nodeSpacing': 30, 'rankSpacing': 30}} }%%
+flowchart LR
+    classDef EXIST fill:#888,color:#000,stroke:#000
+    classDef DONE fill:#3c3,color:#000,stroke:#000
+    classDef NEW_DONE fill:#3c3,color:#000,stroke:#f00,stroke-width:2,stroke-dasharray:5
+    classDef WIP fill:#cc3,color:#000,stroke:#000
+    classDef NEW_WIP fill:#cc3,color:#000,stroke:#f00,stroke-width:2,stroke-dasharray:5
+    classDef TODO fill:#c33,color:#000,stroke:#000
+    classDef NEW_TODO fill:#c33,color:#000,stroke:#f00,stroke-width:2,stroke-dasharray:5
+    classDef NEW fill:#fff,color:#000,stroke:#f00,stroke-width:2,stroke-dasharray:5
+
+    subgraph Legend
+      direction LR 
+      EXIST:::EXIST ~~~ TODO:::TODO ~~~ WIP:::WIP ~~~ DONE:::DONE ~~~  NEW:::NEW
+    end
+
+    msys2-runtime-devel["`
+        msys2-runtime-devel
+        host: x86_64-pc-msys
+        target: aarch64-pc-msys
+    `"]:::DONE
+    
+    mingw-w64-cross-gcc["`
+        mingw-w64-cross-gcc
+        host: x86_64-pc-msys
+        target: aarch64-w64-mingw32
+    `"]:::DONE
+
+    mingw-w64-cross-crt["`
+        mingw-w64-cross-crt
+        host: aarch64-w64-mingw32
+    `"]:::DONE
+
+    mingw-w64-cross-zlib["`
+        mingw-w64-cross-zlib
+        host: aarch64-w64-mingw32
+    `"]:::DONE
+
+    msys2-w32api-headers["`
+        msys2-w32api-headers
+        host: aarch64-pc-msys
+    `"]:::DONE
+
+    msys2-w32api-runtime["`
+        msys2-w32api-runtime
+        host: x86_64-pc-msys
+    `"]:::DONE
+
+    cross-binutils["`
+        cross-binutils
+        host: x86_64-pc-msys
+        target: aarch64-pc-msys
+    `"]:::DONE
+
+    cross-gcc-stage1["`
+        cross-gcc-stage1
+        host: x86_64-pc-msys
+        target: aarch64-pc-msys
+    `"]:::DONE
+
+    cross-gcc["`
+        cross-gcc
+        host: x86_64-pc-msys
+        target: aarch64-pc-msys
+    `"]:::WIP
+
+    windows-default-manifest["`
+        windows-default-manifest
+        host: aarch64-pc-msys
+    `"]:::DONE
+
+    msys2-runtime["`
+        msys2-runtime
+        host: aarch64-pc-msys
+    `"]:::WIP
+
+    bash["`
+       bash
+       host: aarch64-w64-mingw32 
+    `"]:::TODO
+
+    git4win["`
+       Git for Windows
+       host: aarch64-w64-mingw32 
+    `"]:::TODO
+
+        
+    subgraph Stage 1
+        cross-binutils --> cross-gcc-stage1
+        msys2-runtime-devel --> cross-gcc-stage1
+        msys2-w32api-headers --> cross-gcc-stage1
+    end
+
+    subgraph Stage 2 Dependencies
+        mingw-w64-cross-gcc --> msys2-w32api-runtime 
+        msys2-w32api-headers --> msys2-w32api-runtime 
+
+        cross-gcc-stage1 --> windows-default-manifest
+    end
+
+    subgraph Stage 2
+        cross-gcc-stage1 --> cross-gcc
+        msys2-w32api-runtime --> cross-gcc
+        windows-default-manifest --> cross-gcc
+    end
+
+    subgraph Application\nDependencies
+        cross-gcc --> msys2-runtime
+        mingw-w64-cross-gcc --> msys2-runtime
+        mingw-w64-cross-crt --> msys2-runtime
+        mingw-w64-cross-zlib --> msys2-runtime
+    end
+
+    subgraph Application
+        cross-gcc --> bash
+        msys2-runtime --> bash
+
+        cross-gcc --> git4win
+        msys2-runtime --> git4win
+        bash --> git4win
+    end
+```


### PR DESCRIPTION
Builds MinGW toolchain MSYS2 packages with `aarch64-w64-mingw32` target and deploys them to GitHub Pages as Pacman repository overlay.

One can preview the README, e.g. here [Windows-on-ARM-Experiments/msys2-woarm64-build at msys2-workflow (github.com)](https://github.com/Windows-on-ARM-Experiments/msys2-woarm64-build/tree/msys2-workflow)