### PR TITLE
Add build of `mingw-w64-cross-zlib` to `main.yml` and `build.sh`

### DIFF
--- a/.github/scripts/build-package.sh
+++ b/.github/scripts/build-package.sh
@@ -15,6 +15,7 @@ ARGUMENTS="--syncdeps \
     --noconfirm \
     --noprogressbar \
     --nocheck \
+    --skippgpcheck \
     --force \
     $([ "$NO_EXTRACT" = 1 ] && echo "--noextract" || echo "") \
     $([ "$CLEAN_BUILD" = 1 ] && echo "--cleanbuild" || echo "") \
@@ -23,7 +24,7 @@ ARGUMENTS="--syncdeps \
 ccache -svv  || true
 
 if [[ "$PACKAGE_REPOSITORY" == *MINGW* ]]; then
-    makepkg-mingw $ARGUMENTS --skippgpcheck
+    makepkg-mingw $ARGUMENTS
 else
     makepkg $ARGUMENTS
 fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
       [
         mingw-w64-cross-headers,
         mingw-w64-cross-binutils,
-        mingw-w64-cross-gcc-stage1,
+        mingw-w64-cross-gcc-stage1
       ]
     uses: ./.github/workflows/build-package.yml
     with:
@@ -69,7 +69,7 @@ jobs:
         mingw-w64-cross-headers,
         mingw-w64-cross-binutils,
         mingw-w64-cross-gcc-stage1,
-        mingw-w64-cross-crt,
+        mingw-w64-cross-crt
       ]
     uses: ./.github/workflows/build-package.yml
     with:
@@ -86,11 +86,28 @@ jobs:
         mingw-w64-cross-gcc-stage1,
         mingw-w64-cross-windows-default-manifest,
         mingw-w64-cross-crt,
-        mingw-w64-cross-winpthreads,
+        mingw-w64-cross-winpthreads
       ]
     uses: ./.github/workflows/build-package.yml
     with:
       package_name: mingw-w64-cross-gcc
+      needs: ${{ toJson(needs) }}
+      packages_repository: Windows-on-ARM-Experiments/MSYS2-packages
+      packages_branch: ${{ github.event.inputs.msys2_packages_branch || 'woarm64' }}
+
+  mingw-w64-cross-zlib:
+    needs: [
+      mingw-w64-cross-headers,
+      mingw-w64-cross-binutils,
+      mingw-w64-cross-windows-default-manifest,
+      mingw-w64-cross-crt,
+      mingw-w64-cross-winpthreads,
+      mingw-w64-cross-gcc
+    ]
+
+    uses: ./.github/workflows/build-package.yml
+    with:
+      package_name: mingw-w64-cross-zlib
       needs: ${{ toJson(needs) }}
       packages_repository: Windows-on-ARM-Experiments/MSYS2-packages
       packages_branch: ${{ github.event.inputs.msys2_packages_branch || 'woarm64' }}
@@ -105,6 +122,7 @@ jobs:
         mingw-w64-cross-crt,
         mingw-w64-cross-winpthreads,
         mingw-w64-cross-gcc,
+        mingw-w64-cross-zlib
       ]
     runs-on: windows-latest
 
@@ -152,6 +170,11 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: mingw-w64-cross-gcc
+
+      - name: Download mingw-w64-cross-zlib
+        uses: actions/download-artifact@v4
+        with:
+          name: mingw-w64-cross-zlib
 
       - name: Setup MSYS2 packages repository
         run: |

--- a/build.sh
+++ b/build.sh
@@ -66,3 +66,9 @@ echo "::group::Build mingw-w64-cross-gcc"
     pacman -U --noconfirm *.pkg.tar.zst
   popd
 echo "::endgroup::"
+
+echo "::group::Build mingw-w64-cross-zlib"
+  pushd ../MSYS2-packages/mingw-w64-cross-zlib
+    makepkg $MAKEPKG_OPTIONS --skippgpcheck
+  popd
+echo "::endgroup::"


### PR DESCRIPTION
The `mingw-w64-cross-zlib` package is needed for native MinGW GCC build.