### PR TITLE
Update cross-compilation toolchain to the new upstream packages

### DIFF
--- a/.github/scripts/pthread-headers-hack-after.sh
+++ b/.github/scripts/pthread-headers-hack-after.sh
@@ -4,7 +4,7 @@ set -e # exit on error
 set -x # echo on
 set -o pipefail # fail of any command in pipeline is an error
 
-pacman -R --noconfirm mingw-w64-cross-winpthreads || true
+pacman -R --noconfirm mingw-w64-cross-mingw64-winpthreads || true
 rm -rf /opt/aarch64-w64-mingw32/include/pthread_signal.h
 rm -rf /opt/aarch64-w64-mingw32/include/pthread_unistd.h
 rm -rf /opt/aarch64-w64-mingw32/include/pthread_time.h

--- a/.github/scripts/pthread-headers-hack-before.sh
+++ b/.github/scripts/pthread-headers-hack-before.sh
@@ -4,7 +4,7 @@ set -e # exit on error
 set -x # echo on
 set -o pipefail # fail of any command in pipeline is an error
 
-pacman -S --noconfirm mingw-w64-cross-winpthreads
+pacman -S --noconfirm mingw-w64-cross-mingw64-winpthreads
 cp /opt/x86_64-w64-mingw32/include/pthread_signal.h /opt/aarch64-w64-mingw32/include/
 cp /opt/x86_64-w64-mingw32/include/pthread_unistd.h /opt/aarch64-w64-mingw32/include/
 cp /opt/x86_64-w64-mingw32/include/pthread_time.h /opt/aarch64-w64-mingw32/include/

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -38,6 +38,8 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           msystem: ${{ contains(inputs.packages_repository, 'MINGW') && 'MINGW64' || 'MSYS' }}
+          update: true
+          cache: true
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -62,8 +64,8 @@ jobs:
         run: |
           `cygpath "${{ github.workspace }}"`/.github/scripts/install-artifacts.sh
 
-      - name: Copy missing headers for mingw-w64-cross-crt
-        if: ${{ inputs.package_name == 'mingw-w64-cross-crt' }}
+      - name: Copy missing headers for mingw-w64-cross-mingwarm64-crt
+        if: ${{ inputs.package_name == 'mingw-w64-cross-mingwarm64-crt' }}
         run: |
           `cygpath "${{ github.workspace }}"`/.github/scripts/pthread-headers-hack-before.sh
 

--- a/.github/workflows/check-repository.yml
+++ b/.github/workflows/check-repository.yml
@@ -27,7 +27,8 @@ jobs:
 
       - name: Install toolchain
         run: |
-          pacman -S mingw-w64-cross-gcc --noconfirm
+          pacman -S mingw-w64-cross-mingwarm64-gcc --noconfirm
+          pacman -S mingw-w64-aarch64-cc --noconfirm
 
       - name: Build hello-world.exe
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
           path: "."
 
   deploy:
-    if: github.ref == 'refs/heads/main'
+    #if: github.ref == 'refs/heads/main'
     name: Deploy MSYS2 repository
     needs: repository
     runs-on: ubuntu-latest

--- a/.github/workflows/mingw-cross-toolchain.yml
+++ b/.github/workflows/mingw-cross-toolchain.yml
@@ -19,100 +19,103 @@ on:
         value: ${{ toJson(jobs) }}
 
 jobs:
-  mingw-w64-cross-headers:
+  mingw-w64-cross-mingwarm64-headers:
     uses: ./.github/workflows/build-package.yml
     with:
-      package_name: mingw-w64-cross-headers
+      package_name: mingw-w64-cross-mingwarm64-headers
       packages_repository: Windows-on-ARM-Experiments/MSYS2-packages
       packages_branch: ${{ github.event.inputs.msys2_packages_branch || 'woarm64' }}
 
-  mingw-w64-cross-binutils:
-    needs: mingw-w64-cross-headers
+  mingw-w64-cross-mingwarm64-binutils:
+    needs: mingw-w64-cross-mingwarm64-headers
     uses: ./.github/workflows/build-package.yml
     with:
-      package_name: mingw-w64-cross-binutils
+      package_name: mingw-w64-cross-mingwarm64-binutils
       needs: ${{ toJson(needs) }}
       packages_repository: Windows-on-ARM-Experiments/MSYS2-packages
       packages_branch: ${{ github.event.inputs.msys2_packages_branch || 'woarm64' }}
 
-  mingw-w64-cross-gcc-stage1:
-    needs: [mingw-w64-cross-headers, mingw-w64-cross-binutils]
-    uses: ./.github/workflows/build-package.yml
-    with:
-      package_name: mingw-w64-cross-gcc-stage1
-      needs: ${{ toJson(needs) }}
-      packages_repository: Windows-on-ARM-Experiments/MSYS2-packages
-      packages_branch: ${{ github.event.inputs.msys2_packages_branch || 'woarm64' }}
-
-  mingw-w64-cross-windows-default-manifest:
-    needs: [mingw-w64-cross-binutils, mingw-w64-cross-gcc-stage1]
-    uses: ./.github/workflows/build-package.yml
-    with:
-      package_name: mingw-w64-cross-windows-default-manifest
-      needs: ${{ toJson(needs) }}
-      packages_repository: Windows-on-ARM-Experiments/MSYS2-packages
-      packages_branch: ${{ github.event.inputs.msys2_packages_branch || 'woarm64' }}
-
-  mingw-w64-cross-crt:
-    needs:
-      [
-        mingw-w64-cross-headers,
-        mingw-w64-cross-binutils,
-        mingw-w64-cross-gcc-stage1
-      ]
-    uses: ./.github/workflows/build-package.yml
-    with:
-      package_name: mingw-w64-cross-crt
-      needs: ${{ toJson(needs) }}
-      dependencies: mingw-w64-cross-winpthreads
-      packages_repository: Windows-on-ARM-Experiments/MSYS2-packages
-      packages_branch: ${{ github.event.inputs.msys2_packages_branch || 'woarm64' }}
-
-  mingw-w64-cross-winpthreads:
-    needs:
-      [
-        mingw-w64-cross-headers,
-        mingw-w64-cross-binutils,
-        mingw-w64-cross-gcc-stage1,
-        mingw-w64-cross-crt
-      ]
-    uses: ./.github/workflows/build-package.yml
-    with:
-      package_name: mingw-w64-cross-winpthreads
-      needs: ${{ toJson(needs) }}
-      packages_repository: Windows-on-ARM-Experiments/MSYS2-packages
-      packages_branch: ${{ github.event.inputs.msys2_packages_branch || 'woarm64' }}
-
-  mingw-w64-cross-gcc:
-    needs:
-      [
-        mingw-w64-cross-headers,
-        mingw-w64-cross-binutils,
-        mingw-w64-cross-gcc-stage1,
-        mingw-w64-cross-windows-default-manifest,
-        mingw-w64-cross-crt,
-        mingw-w64-cross-winpthreads
-      ]
-    uses: ./.github/workflows/build-package.yml
-    with:
-      package_name: mingw-w64-cross-gcc
-      needs: ${{ toJson(needs) }}
-      packages_repository: Windows-on-ARM-Experiments/MSYS2-packages
-      packages_branch: ${{ github.event.inputs.msys2_packages_branch || 'woarm64' }}
-
-  mingw-w64-cross-zlib:
+  mingw-w64-cross-mingwarm64-gcc-stage1:
     needs: [
-      mingw-w64-cross-headers,
-      mingw-w64-cross-binutils,
-      mingw-w64-cross-windows-default-manifest,
-      mingw-w64-cross-crt,
-      mingw-w64-cross-winpthreads,
-      mingw-w64-cross-gcc
+      mingw-w64-cross-mingwarm64-headers,
+      mingw-w64-cross-mingwarm64-binutils
+    ]
+    uses: ./.github/workflows/build-package.yml
+    with:
+      package_name: mingw-w64-cross-mingwarm64-gcc-stage1
+      needs: ${{ toJson(needs) }}
+      packages_repository: Windows-on-ARM-Experiments/MSYS2-packages
+      packages_branch: ${{ github.event.inputs.msys2_packages_branch || 'woarm64' }}
+
+  mingw-w64-cross-mingwarm64-windows-default-manifest:
+    needs: [
+      mingw-w64-cross-mingwarm64-binutils,
+      mingw-w64-cross-mingwarm64-gcc-stage1
+    ]
+    uses: ./.github/workflows/build-package.yml
+    with:
+      package_name: mingw-w64-cross-mingwarm64-windows-default-manifest
+      needs: ${{ toJson(needs) }}
+      packages_repository: Windows-on-ARM-Experiments/MSYS2-packages
+      packages_branch: ${{ github.event.inputs.msys2_packages_branch || 'woarm64' }}
+
+  mingw-w64-cross-mingwarm64-crt:
+    needs: [
+      mingw-w64-cross-mingwarm64-headers,
+      mingw-w64-cross-mingwarm64-binutils,
+      mingw-w64-cross-mingwarm64-gcc-stage1
+    ]
+    uses: ./.github/workflows/build-package.yml
+    with:
+      package_name: mingw-w64-cross-mingwarm64-crt
+      needs: ${{ toJson(needs) }}
+      dependencies: mingw-w64-cross-mingw64-winpthreads
+      packages_repository: Windows-on-ARM-Experiments/MSYS2-packages
+      packages_branch: ${{ github.event.inputs.msys2_packages_branch || 'woarm64' }}
+
+  mingw-w64-cross-mingwarm64-winpthreads:
+    needs: [
+      mingw-w64-cross-mingwarm64-headers,
+      mingw-w64-cross-mingwarm64-binutils,
+      mingw-w64-cross-mingwarm64-gcc-stage1,
+      mingw-w64-cross-mingwarm64-crt
+    ]
+    uses: ./.github/workflows/build-package.yml
+    with:
+      package_name: mingw-w64-cross-mingwarm64-winpthreads
+      needs: ${{ toJson(needs) }}
+      packages_repository: Windows-on-ARM-Experiments/MSYS2-packages
+      packages_branch: ${{ github.event.inputs.msys2_packages_branch || 'woarm64' }}
+
+  mingw-w64-cross-mingwarm64-gcc:
+    needs: [
+      mingw-w64-cross-mingwarm64-headers,
+      mingw-w64-cross-mingwarm64-binutils,
+      mingw-w64-cross-mingwarm64-gcc-stage1,
+      mingw-w64-cross-mingwarm64-windows-default-manifest,
+      mingw-w64-cross-mingwarm64-crt,
+      mingw-w64-cross-mingwarm64-winpthreads
+    ]
+    uses: ./.github/workflows/build-package.yml
+    with:
+      package_name: mingw-w64-cross-mingwarm64-gcc
+      needs: ${{ toJson(needs) }}
+      packages_repository: Windows-on-ARM-Experiments/MSYS2-packages
+      packages_branch: ${{ github.event.inputs.msys2_packages_branch || 'woarm64' }}
+
+  mingw-w64-cross-mingwarm64-zlib:
+    needs: [
+      mingw-w64-cross-mingwarm64-headers,
+      mingw-w64-cross-mingwarm64-binutils,
+      mingw-w64-cross-mingwarm64-windows-default-manifest,
+      mingw-w64-cross-mingwarm64-crt,
+      mingw-w64-cross-mingwarm64-winpthreads,
+      mingw-w64-cross-mingwarm64-gcc
     ]
 
     uses: ./.github/workflows/build-package.yml
     with:
-      package_name: mingw-w64-cross-zlib
+      package_name: mingw-w64-cross-mingwarm64-zlib
       needs: ${{ toJson(needs) }}
       packages_repository: Windows-on-ARM-Experiments/MSYS2-packages
       packages_branch: ${{ github.event.inputs.msys2_packages_branch || 'woarm64' }}

--- a/build.sh
+++ b/build.sh
@@ -10,64 +10,65 @@ if [ "$CLEAN_BUILD" = 1 ] ; then
   MAKEPKG_OPTIONS="$MAKEPKG_OPTIONS --cleanbuild"
 fi
 
-pacman -R --noconfirm mingw-w64-cross-gcc || true
-pacman -R --noconfirm mingw-w64-cross-winpthreads || true
-pacman -R --noconfirm mingw-w64-cross-crt || true
-pacman -R --noconfirm mingw-w64-cross-windows-default-manifest || true
-pacman -R --noconfirm mingw-w64-cross-gcc-stage1 || true
-pacman -R --noconfirm mingw-w64-cross-binutils || true
-pacman -R --noconfirm mingw-w64-cross-headers || true
+pacman -R --noconfirm mingw-w64-cross-mingwarm64-zlib || true
+pacman -R --noconfirm mingw-w64-cross-mingwarm64-gcc || true
+pacman -R --noconfirm mingw-w64-cross-mingwarm64-winpthreads || true
+pacman -R --noconfirm mingw-w64-cross-mingwarm64-crt || true
+pacman -R --noconfirm mingw-w64-cross-mingwarm64-windows-default-manifest || true
+pacman -R --noconfirm mingw-w64-cross-mingwarm64-gcc-stage1 || true
+pacman -R --noconfirm mingw-w64-cross-mingwarm64-binutils || true
+pacman -R --noconfirm mingw-w64-cross-mingwarm64-headers || true
 
 pacman -S --noconfirm base-devel
 
-echo "::group::Build mingw-w64-cross-headers"
-  pushd ../MSYS2-packages/mingw-w64-cross-headers
+echo "::group::Build mingw-w64-cross-mingwarm64-headers"
+  pushd ../MSYS2-packages/mingw-w64-cross-mingwarm64-headers
     makepkg $MAKEPKG_OPTIONS
   popd
 echo "::endgroup::"
 
-echo "::group::Build mingw-w64-cross-binutils"
-  pushd ../MSYS2-packages/mingw-w64-cross-binutils
+echo "::group::Build mingw-w64-cross-mingwarm64-binutils"
+  pushd ../MSYS2-packages/mingw-w64-cross-mingwarm64-binutils
     makepkg $MAKEPKG_OPTIONS
   popd
 echo "::endgroup::"
 
-echo "::group::Build mingw-w64-cross-gcc-stage1"
-  pushd ../MSYS2-packages/mingw-w64-cross-gcc-stage1
+echo "::group::Build mingw-w64-cross-mingwarm64-gcc-stage1"
+  pushd ../MSYS2-packages/mingw-w64-cross-mingwarm64-gcc-stage1
     makepkg $MAKEPKG_OPTIONS
   popd
 echo "::endgroup::"
 
-echo "::group::Build mingw-w64-cross-windows-default-manifest"
-  pushd ../MSYS2-packages/mingw-w64-cross-windows-default-manifest
+echo "::group::Build mingw-w64-cross-mingwarm64-windows-default-manifest"
+  pushd ../MSYS2-packages/mingw-w64-cross-mingwarm64-windows-default-manifest
     makepkg $MAKEPKG_OPTIONS
   popd
 echo "::endgroup::"
 
-echo "::group::Build mingw-w64-cross-crt"
+echo "::group::Build mingw-w64-cross-mingwarm64-crt"
   .github/scripts/pthread-headers-hack-before.sh
-  pushd ../MSYS2-packages/mingw-w64-cross-crt
+  pushd ../MSYS2-packages/mingw-w64-cross-mingwarm64-crt
     makepkg $MAKEPKG_OPTIONS
   popd
   .github/scripts/pthread-headers-hack-after.sh
 echo "::endgroup::"
 
-echo "::group::Build mingw-w64-cross-winpthreads"
-  pushd ../MSYS2-packages/mingw-w64-cross-winpthreads
+echo "::group::Build mingw-w64-cross-mingwarm64-winpthreads"
+  pushd ../MSYS2-packages/mingw-w64-cross-mingwarm64-winpthreads
     makepkg $MAKEPKG_OPTIONS
   popd
 echo "::endgroup::"
 
-echo "::group::Build mingw-w64-cross-gcc"
-  pushd ../MSYS2-packages/mingw-w64-cross-gcc
+echo "::group::Build mingw-w64-cross-mingwarm64-gcc"
+  pushd ../MSYS2-packages/mingw-w64-cross-mingwarm64-gcc
     makepkg ${MAKEPKG_OPTIONS//--install/}
-    pacman -R --noconfirm mingw-w64-cross-gcc-stage1 || true
+    pacman -R --noconfirm mingw-w64-cross-mingwarm64-gcc-stage1 || true
     pacman -U --noconfirm *.pkg.tar.zst
   popd
 echo "::endgroup::"
 
-echo "::group::Build mingw-w64-cross-zlib"
-  pushd ../MSYS2-packages/mingw-w64-cross-zlib
+echo "::group::Build mingw-w64-cross-mingwarm64-zlib"
+  pushd ../MSYS2-packages/mingw-w64-cross-mingwarm64-zlib
     makepkg $MAKEPKG_OPTIONS --skippgpcheck
   popd
 echo "::endgroup::"


### PR DESCRIPTION
`aarch64-w64-mingw32` target was already added to upstream `mingw-w64-cross-headers` recipe as a `mingw-w64-cross-mingwarm64-headers` package. `aarch64-w64-mingw32` target was also added to upstream as a separate `mingw-w64-cross-mingwarm64-binutils` recipe. This PR continues this work and builds all the remaining cross-compilation toolchain packages in the same style. The new package recipes are in [woarm64](https://github.com/msys2/MSYS2-packages/compare/master...Windows-on-ARM-Experiments:MSYS2-packages:woarm64) branch while the old structure recipes were backed up as [woarm64-v1](https://github.com/msys2/MSYS2-packages/compare/master...Windows-on-ARM-Experiments:MSYS2-packages:woarm64-v1) branch.