### PR TITLE
Another iteration of build and deploy of native MinGW toolchain with itself

### DIFF
--- a/.github/scripts/download-artifacts.sh
+++ b/.github/scripts/download-artifacts.sh
@@ -8,6 +8,6 @@ for ARG in "${@:2}"; do
     NEEDS=`echo "$ARG" | /mingw64/bin/jq 'keys|join(" ")' | sed 's/"//g'`
     for NEED in $NEEDS; do
         echo "Downloading $NEED artifact."
-        /mingw64/bin/gh run download $RUN_ID -n $NEED
+        /mingw64/bin/gh run download $RUN_ID -n $NEED || true
     done
 done

--- a/.github/scripts/enable-ccache.sh
+++ b/.github/scripts/enable-ccache.sh
@@ -2,6 +2,8 @@
 
 source `dirname ${BASH_SOURCE[0]}`/../../config.sh
 
+PACKAGE_REPOSITORY=$1
+
 DIR="`dirname ${BASH_SOURCE[0]}`/../.."
 DIR=`realpath $DIR`
 CCACHE_DIR=$DIR/ccache
@@ -32,7 +34,11 @@ pushd /
   echo "::endgroup::"
 popd
 
-pacman -S --noconfirm ccache
+if [[ "$PACKAGE_REPOSITORY" == *MINGW* ]]; then
+  pacman -S --noconfirm mingw-w64-clang-aarch64-ccache
+else
+  pacman -S --noconfirm ccache
+fi
 
 pushd /usr/lib/ccache/bin
   echo "::group::Add aarch64 toolchain to ccache"
@@ -40,8 +46,5 @@ pushd /usr/lib/ccache/bin
     ln -sf /usr/bin/ccache aarch64-w64-mingw32-c++
     ln -sf /usr/bin/ccache aarch64-w64-mingw32-g++
     ln -sf /usr/bin/ccache aarch64-w64-mingw32-gcc
-    if [[ "$FLAVOR" = "CROSS" ]]; then
-        ln -sf /usr/bin/true makeinfo
-    fi
   echo "::endgroup::"
 popd

--- a/.github/scripts/install-artifacts.sh
+++ b/.github/scripts/install-artifacts.sh
@@ -2,4 +2,8 @@
 
 source `dirname ${BASH_SOURCE[0]}`/../../config.sh
 
-pacman -U --noconfirm *.pkg.tar.zst
+if [[ $(ls *.pkg.tar.zst 2>/dev/null) != "" ]]; then
+    pacman -U --noconfirm *.pkg.tar.zst
+else
+    echo "No package file found. Skipping installation."
+fi

--- a/.github/scripts/pthread-headers-hack-after.sh
+++ b/.github/scripts/pthread-headers-hack-after.sh
@@ -6,3 +6,4 @@ pacman -R --noconfirm mingw-w64-cross-mingw64-winpthreads || true
 rm -rf /opt/aarch64-w64-mingw32/include/pthread_signal.h
 rm -rf /opt/aarch64-w64-mingw32/include/pthread_unistd.h
 rm -rf /opt/aarch64-w64-mingw32/include/pthread_time.h
+rm -rf /opt/aarch64-w64-mingw32/include/pthread_compat.h

--- a/.github/scripts/pthread-headers-hack-before.sh
+++ b/.github/scripts/pthread-headers-hack-before.sh
@@ -6,3 +6,4 @@ pacman -S --noconfirm mingw-w64-cross-mingw64-winpthreads
 cp /opt/x86_64-w64-mingw32/include/pthread_signal.h /opt/aarch64-w64-mingw32/include/
 cp /opt/x86_64-w64-mingw32/include/pthread_unistd.h /opt/aarch64-w64-mingw32/include/
 cp /opt/x86_64-w64-mingw32/include/pthread_time.h /opt/aarch64-w64-mingw32/include/
+cp /opt/x86_64-w64-mingw32/include/pthread_compat.h /opt/aarch64-w64-mingw32/include/

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -3,6 +3,10 @@ name: Build MSYS2 package
 on:
   workflow_call:
     inputs:
+      if:
+        description: "Condition allowing to skip all steps of the workflow job"
+        type: boolean
+        default: true
       package_name:
         description: "Package name to build"
         type: string
@@ -30,10 +34,6 @@ on:
         type: string
         default: ""
 
-defaults:
-  run:
-    shell: msys2 {0}
-
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   FLAVOR: ${{ (inputs.runner_arch == 'aarch64') && (inputs.build_with_native && 'NATIVE_WITH_NATIVE' || 'NATIVE_WITH_CROSS') || 'CROSS' }}
@@ -41,16 +41,20 @@ env:
 
 jobs:
   build:
-    name: Build ${{ inputs.package_name }}
+    name: ${{ inputs.if && 'Build' || 'Skip'}} ${{ inputs.package_name }}
     timeout-minutes: 720
     runs-on: >-
       ${{ fromJson(inputs.runner_arch == 'aarch64'
         && '["Windows", "ARM64", "MSYS2"]'
         || '["windows-latest"]') }}
 
+    defaults:
+     run:
+       shell: msys2 {0}
+
     steps:
       - name: Kill hanging processes
-        if: inputs.runner_arch == 'aarch64'
+        if: inputs.if && inputs.runner_arch == 'aarch64'
         shell: powershell
         run: |
           taskkill /F /FI 'MODULES eq msys-2.0.dll'
@@ -59,6 +63,7 @@ jobs:
           exit 0
 
       - uses: Windows-on-ARM-Experiments/setup-msys2@main
+        if: inputs.if
         timeout-minutes: 10
         with:
           msystem: >-
@@ -70,9 +75,11 @@ jobs:
           cache: true
 
       - name: Checkout repository
+        if: inputs.if
         uses: actions/checkout@v4
 
       - name: Checkout ${{ inputs.packages_repository }} repository
+        if: inputs.if
         uses: actions/checkout@v4
         with:
           repository: ${{ inputs.packages_repository }}
@@ -81,43 +88,46 @@ jobs:
           path: ${{ github.workspace }}/packages
 
       - name: Setup packages repository
-        if: inputs.runner_arch == 'aarch64'
+        if: inputs.if && inputs.runner_arch == 'aarch64'
         run: |
           `cygpath "${{ github.workspace }}"`/.github/scripts/setup-repository.sh
 
       - name: Install dependencies
+        if: inputs.if
         run: >-
           `cygpath "${{ github.workspace }}"`/.github/scripts/install-dependencies.sh \
             "git mingw-w64-x86_64-github-cli mingw-w64-x86_64-jq ${{ inputs.dependencies }}"
 
       - name: Download artifacts
-        if: inputs.needs
+        if: inputs.if && inputs.needs
         run: |
           `cygpath "${{ github.workspace }}"`/.github/scripts/download-artifacts.sh \
             ${{ github.run_id }} \
             '${{ inputs.needs }}'
 
       - name: Install artifacts
-        if: inputs.needs
+        if: inputs.if && inputs.needs
         run: |
           `cygpath "${{ github.workspace }}"`/.github/scripts/install-artifacts.sh
 
       - name: Copy missing headers for mingw-w64-cross-mingwarm64-crt
-        if: inputs.package_name == 'mingw-w64-cross-mingwarm64-crt'
+        if: inputs.if && inputs.package_name == 'mingw-w64-cross-mingwarm64-crt'
         run: |
           `cygpath "${{ github.workspace }}"`/.github/scripts/pthread-headers-hack-before.sh
 
       - name: Setup MINGWARM64 environment
-        if: inputs.runner_arch == 'aarch64'
+        if: inputs.if && inputs.runner_arch == 'aarch64'
         run: |
           `cygpath "${{ github.workspace }}"`/.github/scripts/setup-mingwarm64.sh
 
       - name: Enable Ccache
+        if: inputs.if
         id: enable-ccache
         run: |
           `cygpath "${{ github.workspace }}"`/.github/scripts/enable-ccache.sh
 
       - name: Restore Ccache
+        if: inputs.if
         uses: actions/cache/restore@v4
         with:
           path: ${{ github.workspace }}/ccache
@@ -125,6 +135,7 @@ jobs:
           restore-keys: ${{ inputs.package_name }}-
 
       - name: Build ${{ inputs.package_name }}
+        if: inputs.if
         timeout-minutes: 720
         working-directory: ${{ github.workspace }}/packages/${{ inputs.package_name }}
         run: |
@@ -132,13 +143,14 @@ jobs:
             ${{ inputs.packages_repository }}
 
       - name: Save Ccache
-        if: always()
+        if: inputs.if && always()
         uses: actions/cache/save@v4
         with:
           path: ${{ github.workspace }}/ccache
           key: ${{ inputs.package_name }}-ccache-${{ steps.enable-ccache.outputs.timestamp }}
 
       - name: Upload ${{ inputs.package_name }}
+        if: inputs.if
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.package_name }}
@@ -146,7 +158,7 @@ jobs:
           path: ${{ github.workspace }}/packages/${{ inputs.package_name }}/*.pkg.tar.zst
 
       - name: Upload build folder
-        if: failure()
+        if: inputs.if && failure()
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.package_name }}-build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,7 +115,7 @@ jobs:
           path: repository
 
   deploy:
-    if: github.ref == 'refs/heads/main'
+    #if: github.ref == 'refs/heads/main'
     name: Deploy MSYS2 repository
     needs: repository
     runs-on: ubuntu-latest

--- a/.github/workflows/mingw-native-toolchain.yml
+++ b/.github/workflows/mingw-native-toolchain.yml
@@ -32,26 +32,123 @@ on:
         value: ${{ toJson(jobs) }}
 
 jobs:
+  mingw-w64-libtool:
+    uses: ./.github/workflows/build-package.yml
+    with:
+      if: ${{ inputs.build_with_native != 'false' }}
+      package_name: mingw-w64-libtool
+      packages_repository: Windows-on-ARM-Experiments/MINGW-packages
+      packages_branch: ${{ inputs.mingw_packages_branch || 'woarm64' }}
+      runner_arch: aarch64
+      build_with_native: ${{ inputs.build_with_native != 'false' }}
+
+  mingw-w64-ninja:
+    uses: ./.github/workflows/build-package.yml
+    with:
+      if: ${{ inputs.build_with_native != 'false' }}
+      package_name: mingw-w64-ninja
+      packages_repository: Windows-on-ARM-Experiments/MINGW-packages
+      packages_branch: ${{ inputs.mingw_packages_branch || 'woarm64' }}
+      runner_arch: aarch64
+      build_with_native: ${{ inputs.build_with_native != 'false' }}
+
+  mingw-w64-pkgconf:
+    needs: [
+      mingw-w64-ninja
+    ]
+    uses: ./.github/workflows/build-package.yml
+    with:
+      if: ${{ inputs.build_with_native != 'false' }}
+      package_name: mingw-w64-pkgconf
+      packages_repository: Windows-on-ARM-Experiments/MINGW-packages
+      packages_branch: ${{ inputs.mingw_packages_branch || 'woarm64' }}
+      runner_arch: aarch64
+      build_with_native: ${{ inputs.build_with_native != 'false' }}
+      needs: ${{ toJson(needs) }}
+
+  mingw-w64-autotools:
+    needs: [
+      mingw-w64-libtool,
+      mingw-w64-pkgconf
+    ]
+    uses: ./.github/workflows/build-package.yml
+    with:
+      if: ${{ inputs.build_with_native != 'false' }}
+      package_name: mingw-w64-autotools
+      packages_repository: Windows-on-ARM-Experiments/MINGW-packages
+      packages_branch: ${{ inputs.mingw_packages_branch || 'woarm64' }}
+      runner_arch: aarch64
+      build_with_native: ${{ inputs.build_with_native != 'false' }}
+      needs: ${{ toJson(needs) }}
+
+  autotools-wrappers:
+    needs: [
+      mingw-w64-libtool,
+      mingw-w64-pkgconf,
+      mingw-w64-autotools
+    ]
+    uses: ./.github/workflows/build-package.yml
+    with:
+      if: ${{ inputs.build_with_native != 'false' }}
+      package_name: autotools-wrappers
+      packages_repository: Windows-on-ARM-Experiments/MSYS2-packages
+      packages_branch: ${{ inputs.mingw_packages_branch || 'woarm64' }}
+      runner_arch: aarch64
+      build_with_native: ${{ inputs.build_with_native != 'false' }}
+      needs: ${{ toJson(needs) }}
+
+  mingw-w64-gperf:
+    needs: [
+      mingw-w64-libtool,
+      mingw-w64-pkgconf,
+      mingw-w64-autotools
+    ]
+    uses: ./.github/workflows/build-package.yml
+    with:
+      if: ${{ inputs.build_with_native != 'false' }}
+      package_name: mingw-w64-gperf
+      packages_repository: Windows-on-ARM-Experiments/MINGW-packages
+      packages_branch: ${{ inputs.mingw_packages_branch || 'woarm64' }}
+      runner_arch: aarch64
+      build_with_native: ${{ inputs.build_with_native != 'false' }}
+      needs: ${{ toJson(needs) }}
+
   mingw-w64-libiconv:
     uses: ./.github/workflows/build-package.yml
+    needs: [
+      mingw-w64-libtool,
+      mingw-w64-pkgconf,
+      mingw-w64-autotools,
+      mingw-w64-gperf
+    ]
     with:
       package_name: mingw-w64-libiconv
       packages_repository: Windows-on-ARM-Experiments/MINGW-packages
       packages_branch: ${{ inputs.mingw_packages_branch || 'woarm64' }}
       runner_arch: aarch64
       build_with_native: ${{ inputs.build_with_native != 'false' }}
+      needs: ${{ toJson(needs) }}
 
   mingw-w64-libtre:
     uses: ./.github/workflows/build-package.yml
+    needs: [
+      mingw-w64-libtool,
+      mingw-w64-pkgconf,
+      mingw-w64-autotools
+    ]
     with:
       package_name: mingw-w64-libtre
       packages_repository: Windows-on-ARM-Experiments/MINGW-packages
       packages_branch: ${{ inputs.mingw_packages_branch || 'woarm64' }}
       runner_arch: aarch64
       build_with_native: ${{ inputs.build_with_native != 'false' }}
+      needs: ${{ toJson(needs) }}
 
   mingw-w64-libsystre:
     needs: [
+      mingw-w64-libtool,
+      mingw-w64-pkgconf,
+      mingw-w64-autotools,
       mingw-w64-libtre
     ]
     uses: ./.github/workflows/build-package.yml
@@ -65,6 +162,10 @@ jobs:
 
   mingw-w64-gettext:
     needs: [
+      mingw-w64-libtool,
+      mingw-w64-pkgconf,
+      mingw-w64-autotools,
+      mingw-w64-gperf,
       mingw-w64-libiconv,
       mingw-w64-libtre,
       mingw-w64-libsystre
@@ -80,6 +181,10 @@ jobs:
 
   mingw-w64-ncurses:
     needs: [
+      mingw-w64-libtool,
+      mingw-w64-pkgconf,
+      mingw-w64-autotools,
+      mingw-w64-gperf,
       mingw-w64-libiconv,
       mingw-w64-libtre,
       mingw-w64-libsystre,
@@ -94,53 +199,26 @@ jobs:
       build_with_native: ${{ inputs.build_with_native != 'false' }}
       needs: ${{ toJson(needs) }}
 
-  mingw-w64-headers-git:
-    uses: ./.github/workflows/build-package.yml
-    with:
-      package_name: mingw-w64-headers-git
-      packages_repository: Windows-on-ARM-Experiments/MINGW-packages
-      packages_branch: ${{ inputs.mingw_packages_branch || 'woarm64' }}
-      runner_arch: aarch64
-      build_with_native: ${{ inputs.build_with_native != 'false' }}
-
-  mingw-w64-crt-git:
-    needs: [
-      mingw-w64-headers-git
-    ]
-    uses: ./.github/workflows/build-package.yml
-    with:
-      package_name: mingw-w64-crt-git
-      packages_repository: Windows-on-ARM-Experiments/MINGW-packages
-      packages_branch: ${{ inputs.mingw_packages_branch || 'woarm64' }}
-      runner_arch: aarch64
-      build_with_native: ${{ inputs.build_with_native != 'false' }}
-      needs: ${{ toJson(needs) }}
-
-  mingw-w64-winpthreads-git:
-    needs: [
-      mingw-w64-headers-git,
-      mingw-w64-crt-git
-    ]
-    uses: ./.github/workflows/build-package.yml
-    with:
-      package_name: mingw-w64-winpthreads-git
-      packages_repository: Windows-on-ARM-Experiments/MINGW-packages
-      packages_branch: ${{ inputs.mingw_packages_branch || 'woarm64' }}
-      runner_arch: aarch64
-      build_with_native: ${{ inputs.build_with_native != 'false' }}
-      needs: ${{ toJson(needs) }}
-
   mingw-w64-bzip2:
     uses: ./.github/workflows/build-package.yml
+    needs: [
+      mingw-w64-libtool,
+      mingw-w64-pkgconf,
+      mingw-w64-autotools
+    ]
     with:
       package_name: mingw-w64-bzip2
       packages_repository: Windows-on-ARM-Experiments/MINGW-packages
       packages_branch: ${{ inputs.mingw_packages_branch || 'woarm64' }}
       runner_arch: aarch64
       build_with_native: ${{ inputs.build_with_native != 'false' }}
+      needs: ${{ toJson(needs) }}
 
   mingw-w64-zlib:
     needs: [
+      mingw-w64-libtool,
+      mingw-w64-pkgconf,
+      mingw-w64-autotools,
       mingw-w64-bzip2
     ]
     uses: ./.github/workflows/build-package.yml
@@ -153,6 +231,9 @@ jobs:
       needs: ${{ toJson(needs) }}
 
   mingw-w64-zstd:
+    needs: [
+      mingw-w64-ninja
+    ]
     uses: ./.github/workflows/build-package.yml
     with:
       package_name: mingw-w64-zstd
@@ -160,8 +241,14 @@ jobs:
       packages_branch: ${{ inputs.mingw_packages_branch || 'woarm64' }}
       runner_arch: aarch64
       build_with_native: ${{ inputs.build_with_native != 'false' }}
+      needs: ${{ toJson(needs) }}
 
   mingw-w64-gmp:
+    needs: [
+      mingw-w64-libtool,
+      mingw-w64-pkgconf,
+      mingw-w64-autotools
+    ]
     uses: ./.github/workflows/build-package.yml
     with:
       package_name: mingw-w64-gmp
@@ -169,10 +256,14 @@ jobs:
       packages_branch: ${{ inputs.mingw_packages_branch || 'woarm64' }}
       runner_arch: aarch64
       build_with_native: ${{ inputs.build_with_native != 'false' }}
+      needs: ${{ toJson(needs) }}
 
   mingw-w64-mpfr:
     uses: ./.github/workflows/build-package.yml
     needs: [
+      mingw-w64-libtool,
+      mingw-w64-pkgconf,
+      mingw-w64-autotools,
       mingw-w64-gmp
     ]
     with:
@@ -186,6 +277,9 @@ jobs:
   mingw-w64-isl:
     uses: ./.github/workflows/build-package.yml
     needs: [
+      mingw-w64-libtool,
+      mingw-w64-pkgconf,
+      mingw-w64-autotools,
       mingw-w64-gmp
     ]
     with:
@@ -196,8 +290,112 @@ jobs:
       build_with_native: ${{ inputs.build_with_native != 'false' }}
       needs: ${{ toJson(needs) }}
 
+  mingw-w64-mpc:
+    needs: [
+      mingw-w64-libtool,
+      mingw-w64-pkgconf,
+      mingw-w64-autotools,
+      mingw-w64-gmp,
+      mingw-w64-mpfr
+    ]
+    uses: ./.github/workflows/build-package.yml
+    with:
+      package_name: mingw-w64-mpc
+      packages_repository: Windows-on-ARM-Experiments/MINGW-packages
+      packages_branch: ${{ inputs.mingw_packages_branch || 'woarm64' }}
+      runner_arch: aarch64
+      build_with_native: ${{ inputs.build_with_native != 'false' }}
+      needs: ${{ toJson(needs) }}
+
+  mingw-w64-libmangle-git:
+    needs: [
+      mingw-w64-libtool,
+      mingw-w64-pkgconf,
+      mingw-w64-autotools
+    ]
+    uses: ./.github/workflows/build-package.yml
+    with:
+      if: ${{ inputs.build_with_native != 'false' }}
+      package_name: mingw-w64-libmangle-git
+      packages_repository: Windows-on-ARM-Experiments/MINGW-packages
+      packages_branch: ${{ inputs.mingw_packages_branch || 'woarm64' }}
+      runner_arch: aarch64
+      build_with_native: ${{ inputs.build_with_native != 'false' }}
+      needs: ${{ toJson(needs) }}
+
+  mingw-w64-tools-git:
+    needs: [
+      mingw-w64-libtool,
+      mingw-w64-pkgconf,
+      mingw-w64-autotools,
+      mingw-w64-libmangle-git
+    ]
+    uses: ./.github/workflows/build-package.yml
+    with:
+      if: ${{ inputs.build_with_native != 'false' }}
+      package_name: mingw-w64-tools-git
+      packages_repository: Windows-on-ARM-Experiments/MINGW-packages
+      packages_branch: ${{ inputs.mingw_packages_branch || 'woarm64' }}
+      runner_arch: aarch64
+      build_with_native: ${{ inputs.build_with_native != 'false' }}
+      needs: ${{ toJson(needs) }}
+
+  mingw-w64-headers-git:
+    needs: [
+      mingw-w64-libtool,
+      mingw-w64-pkgconf,
+      mingw-w64-autotools,
+      mingw-w64-libmangle-git,
+      mingw-w64-tools-git
+    ]
+    uses: ./.github/workflows/build-package.yml
+    with:
+      package_name: mingw-w64-headers-git
+      packages_repository: Windows-on-ARM-Experiments/MINGW-packages
+      packages_branch: ${{ inputs.mingw_packages_branch || 'woarm64' }}
+      runner_arch: aarch64
+      build_with_native: ${{ inputs.build_with_native != 'false' }}
+      needs: ${{ toJson(needs) }}
+
+  mingw-w64-crt-git:
+    needs: [
+      mingw-w64-libtool,
+      mingw-w64-pkgconf,
+      mingw-w64-autotools,
+      mingw-w64-headers-git
+    ]
+    uses: ./.github/workflows/build-package.yml
+    with:
+      package_name: mingw-w64-crt-git
+      packages_repository: Windows-on-ARM-Experiments/MINGW-packages
+      packages_branch: ${{ inputs.mingw_packages_branch || 'woarm64' }}
+      runner_arch: aarch64
+      build_with_native: ${{ inputs.build_with_native != 'false' }}
+      needs: ${{ toJson(needs) }}
+
+  mingw-w64-winpthreads-git:
+    needs: [
+      mingw-w64-libtool,
+      mingw-w64-pkgconf,
+      mingw-w64-autotools,
+      mingw-w64-headers-git,
+      mingw-w64-crt-git
+    ]
+    uses: ./.github/workflows/build-package.yml
+    with:
+      package_name: mingw-w64-winpthreads-git
+      packages_repository: Windows-on-ARM-Experiments/MINGW-packages
+      packages_branch: ${{ inputs.mingw_packages_branch || 'woarm64' }}
+      runner_arch: aarch64
+      build_with_native: ${{ inputs.build_with_native != 'false' }}
+      needs: ${{ toJson(needs) }}
+
   mingw-w64-binutils:
     needs: [
+      mingw-w64-libtool,
+      mingw-w64-pkgconf,
+      mingw-w64-autotools,
+      mingw-w64-gperf,
       mingw-w64-libiconv,
       mingw-w64-libtre,
       mingw-w64-libsystre,
@@ -221,21 +419,12 @@ jobs:
       build_with_native: ${{ inputs.build_with_native != 'false' }}
       needs: ${{ toJson(needs) }}
 
-  mingw-w64-mpc:
-    needs: [
-      mingw-w64-gmp,
-      mingw-w64-mpfr
-    ]
-    uses: ./.github/workflows/build-package.yml
-    with:
-      package_name: mingw-w64-mpc
-      packages_repository: Windows-on-ARM-Experiments/MINGW-packages
-      packages_branch: ${{ inputs.mingw_packages_branch || 'woarm64' }}
-      runner_arch: aarch64
-      build_with_native: ${{ inputs.build_with_native != 'false' }}
-      needs: ${{ toJson(needs) }}
-
   mingw-w64-windows-default-manifest:
+    needs: [
+      mingw-w64-libtool,
+      mingw-w64-pkgconf,
+      mingw-w64-autotools
+    ]
     uses: ./.github/workflows/build-package.yml
     with:
       package_name: mingw-w64-windows-default-manifest
@@ -243,9 +432,14 @@ jobs:
       packages_branch: ${{ inputs.mingw_packages_branch || 'woarm64' }}
       runner_arch: aarch64
       build_with_native: ${{ inputs.build_with_native != 'false' }}
+      needs: ${{ toJson(needs) }}
 
   mingw-w64-gcc:
     needs: [
+      mingw-w64-libtool,
+      mingw-w64-pkgconf,
+      mingw-w64-autotools,
+      mingw-w64-gperf,
       mingw-w64-libiconv,
       mingw-w64-libtre,
       mingw-w64-libsystre,

--- a/build-native-with-native.sh
+++ b/build-native-with-native.sh
@@ -31,6 +31,12 @@ function build_package () {
 .github/scripts/install-dependencies.sh
 .github/scripts/enable-ccache.sh
 
+build_package mingw-w64-libtool
+build_package mingw-w64-ninja
+build_package mingw-w64-pkgconf
+build_package mingw-w64-autotools
+build_package autotools-wrappers MSYS2
+build_package mingw-w64-gperf
 build_package mingw-w64-libiconv
 build_package mingw-w64-libtre
 build_package mingw-w64-libsystre
@@ -44,6 +50,8 @@ build_package mingw-w64-mpfr
 build_package mingw-w64-isl
 build_package mingw-w64-mpc
 
+build_package mingw-w64-libmangle-git
+build_package mingw-w64-tools-git
 build_package mingw-w64-headers-git
 build_package mingw-w64-crt-git
 build_package mingw-w64-winpthreads-git


### PR DESCRIPTION
In the secod iteration of the native toolchain build the following packages can be build with the toolchain from the previous iteration first and then replace their x64 variants for the second iteration toolchain build:

 - `mingw-w64-libtool`
 - `mingw-w64-ninja`
 - `mingw-w64-pkgconf`
 - `mingw-w64-autotools`
 - `mingw-w64-gperf`

Also, the following utility packages that are part of MinGW codebse can be built afterwards:

 - `mingw-w64-libmangle-git`
 - `mingw-w64-tools-git`

Verified by https://github.com/Windows-on-ARM-Experiments/msys2-woarm64-build/actions/runs/14217604079.