### PR TITLE
Fix regression in pthread header workaround

### DIFF
--- a/.github/scripts/pthread-headers-hack-after.sh
+++ b/.github/scripts/pthread-headers-hack-after.sh
@@ -3,6 +3,7 @@
 source `dirname ${BASH_SOURCE[0]}`/../../config.sh
 
 pacman -R --noconfirm mingw-w64-cross-mingw64-winpthreads || true
+rm -rf /opt/aarch64-w64-mingw32/include/pthread_compat.h
 rm -rf /opt/aarch64-w64-mingw32/include/pthread_signal.h
 rm -rf /opt/aarch64-w64-mingw32/include/pthread_unistd.h
 rm -rf /opt/aarch64-w64-mingw32/include/pthread_time.h

--- a/.github/scripts/pthread-headers-hack-before.sh
+++ b/.github/scripts/pthread-headers-hack-before.sh
@@ -3,6 +3,7 @@
 source `dirname ${BASH_SOURCE[0]}`/../../config.sh
 
 pacman -S --noconfirm mingw-w64-cross-mingw64-winpthreads
+cp /opt/x86_64-w64-mingw32/include/pthread_compat.h /opt/aarch64-w64-mingw32/include/
 cp /opt/x86_64-w64-mingw32/include/pthread_signal.h /opt/aarch64-w64-mingw32/include/
 cp /opt/x86_64-w64-mingw32/include/pthread_unistd.h /opt/aarch64-w64-mingw32/include/
 cp /opt/x86_64-w64-mingw32/include/pthread_time.h /opt/aarch64-w64-mingw32/include/


### PR DESCRIPTION
Upstream pthread headers now depend on another header so copying of that header is needed for zero-level bootstrapping workaround.