### PR TITLE
Harden cross-toolchain bootstrap diagnostics

### DIFF
--- a/.github/scripts/build-hello-world.sh
+++ b/.github/scripts/build-hello-world.sh
@@ -2,6 +2,8 @@
 
 source `dirname ${BASH_SOURCE[0]}`/../../config.sh
 
+SCRIPT_DIR=`dirname ${BASH_SOURCE[0]}`
+
 # Sanity check of the GCC binary and its version.
 aarch64-w64-mingw32-gcc --version
 
@@ -13,3 +15,7 @@ int main() {
 }
 ' > hello-world.c
 aarch64-w64-mingw32-gcc -o hello-world.exe hello-world.c
+
+bash "$SCRIPT_DIR/verify-pe-target.sh" \
+  hello-world.exe \
+  hello-world-architecture.json

--- a/.github/scripts/create-bootstrap-status.py
+++ b/.github/scripts/create-bootstrap-status.py
@@ -36,7 +36,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--package", action="append", required=True, type=component_result)
     parser.add_argument("--verification", required=True, type=component_result)
     parser.add_argument("--architecture-report", type=Path)
-    parser.add_argument("--target", required=True)
+    parser.add_argument("--mingw-target", required=True)
+    parser.add_argument("--runtime-target", required=True)
     parser.add_argument("--packages-repository", required=True)
     parser.add_argument("--packages-ref", required=True)
     parser.add_argument("--run-repository", required=True)
@@ -69,13 +70,16 @@ def main() -> None:
     results = [result for _, result in pipeline]
 
     manifest = {
-        "schema_version": 1,
+        "schema_version": 2,
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "workflow": "mingw-cross-toolchain",
         "status": overall_status(results),
         "first_failure": first_failure,
         "first_incomplete": first_incomplete,
-        "target": args.target,
+        "targets": {
+            "mingw": args.mingw_target,
+            "runtime": args.runtime_target,
+        },
         "source": {
             "repository": args.packages_repository,
             "ref": args.packages_ref,

--- a/.github/scripts/create-bootstrap-status.py
+++ b/.github/scripts/create-bootstrap-status.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+VALID_RESULTS = {"success", "failure", "cancelled", "skipped"}
+
+
+def component_result(value: str) -> tuple[str, str]:
+    name, separator, result = value.rpartition("=")
+    if not separator or not name or result not in VALID_RESULTS:
+        raise argparse.ArgumentTypeError(
+            "component results must use NAME=success|failure|cancelled|skipped"
+        )
+    return name, result
+
+
+def overall_status(results: list[str]) -> str:
+    if "failure" in results:
+        return "failure"
+    if "cancelled" in results:
+        return "cancelled"
+    if all(result == "success" for result in results):
+        return "success"
+    return "incomplete"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Create the cross-toolchain bootstrap status manifest."
+    )
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--package", action="append", required=True, type=component_result)
+    parser.add_argument("--verification", required=True, type=component_result)
+    parser.add_argument("--architecture-report", type=Path)
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--packages-repository", required=True)
+    parser.add_argument("--packages-ref", required=True)
+    parser.add_argument("--run-repository", required=True)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--run-attempt", required=True)
+    parser.add_argument("--run-sha", required=True)
+    parser.add_argument("--run-ref", required=True)
+    parser.add_argument("--run-url", required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    verification_name, verification_result = args.verification
+
+    architecture = None
+    if args.architecture_report and args.architecture_report.exists():
+        with args.architecture_report.open(encoding="utf-8") as report:
+            architecture = json.load(report)
+    if verification_result == "success" and architecture is None:
+        raise ValueError("successful architecture verification must provide its report")
+
+    pipeline = [*args.package, args.verification]
+    first_failure = next(
+        (name for name, result in pipeline if result == "failure"), None
+    )
+    first_incomplete = next(
+        (name for name, result in pipeline if result != "success"), None
+    )
+    results = [result for _, result in pipeline]
+
+    manifest = {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "workflow": "mingw-cross-toolchain",
+        "status": overall_status(results),
+        "first_failure": first_failure,
+        "first_incomplete": first_incomplete,
+        "target": args.target,
+        "source": {
+            "repository": args.packages_repository,
+            "ref": args.packages_ref,
+        },
+        "run": {
+            "repository": args.run_repository,
+            "id": args.run_id,
+            "attempt": args.run_attempt,
+            "sha": args.run_sha,
+            "ref": args.run_ref,
+            "url": args.run_url,
+        },
+        "packages": [
+            {
+                "component": name,
+                "status": result,
+                "artifact": name if result == "success" else None,
+            }
+            for name, result in args.package
+        ],
+        "verification": {
+            "component": verification_name,
+            "status": verification_result,
+            "artifact": verification_name
+            if verification_result == "success"
+            else None,
+            "evidence": architecture,
+        },
+    }
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w", encoding="utf-8") as output:
+        json.dump(manifest, output, indent=2)
+        output.write("\n")
+
+    failure = first_failure or "none"
+    print(f"Bootstrap status: {manifest['status']}; first failure: {failure}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/enable-ccache.sh
+++ b/.github/scripts/enable-ccache.sh
@@ -40,8 +40,5 @@ pushd /usr/lib/ccache/bin
     ln -sf /usr/bin/ccache aarch64-w64-mingw32-c++
     ln -sf /usr/bin/ccache aarch64-w64-mingw32-g++
     ln -sf /usr/bin/ccache aarch64-w64-mingw32-gcc
-    if [[ "$FLAVOR" = "CROSS" ]]; then
-        ln -sf /usr/bin/true makeinfo
-    fi
   echo "::endgroup::"
 popd

--- a/.github/scripts/pthread-headers-hack-after.sh
+++ b/.github/scripts/pthread-headers-hack-after.sh
@@ -3,6 +3,9 @@
 source `dirname ${BASH_SOURCE[0]}`/../../config.sh
 
 pacman -R --noconfirm mingw-w64-cross-mingw64-winpthreads || true
-rm -rf /opt/aarch64-w64-mingw32/include/pthread_signal.h
-rm -rf /opt/aarch64-w64-mingw32/include/pthread_unistd.h
-rm -rf /opt/aarch64-w64-mingw32/include/pthread_time.h
+
+rm -f \
+  /opt/aarch64-w64-mingw32/include/pthread_compat.h \
+  /opt/aarch64-w64-mingw32/include/pthread_signal.h \
+  /opt/aarch64-w64-mingw32/include/pthread_unistd.h \
+  /opt/aarch64-w64-mingw32/include/pthread_time.h

--- a/.github/scripts/pthread-headers-hack-before.sh
+++ b/.github/scripts/pthread-headers-hack-before.sh
@@ -3,6 +3,14 @@
 source `dirname ${BASH_SOURCE[0]}`/../../config.sh
 
 pacman -S --noconfirm mingw-w64-cross-mingw64-winpthreads
-cp /opt/x86_64-w64-mingw32/include/pthread_signal.h /opt/aarch64-w64-mingw32/include/
-cp /opt/x86_64-w64-mingw32/include/pthread_unistd.h /opt/aarch64-w64-mingw32/include/
-cp /opt/x86_64-w64-mingw32/include/pthread_time.h /opt/aarch64-w64-mingw32/include/
+
+for HEADER in \
+  pthread_compat.h \
+  pthread_signal.h \
+  pthread_unistd.h \
+  pthread_time.h
+do
+  install -m 644 \
+    "/opt/x86_64-w64-mingw32/include/$HEADER" \
+    "/opt/aarch64-w64-mingw32/include/$HEADER"
+done

--- a/.github/scripts/verify-pe-target.sh
+++ b/.github/scripts/verify-pe-target.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+source `dirname ${BASH_SOURCE[0]}`/../../config.sh
+
+BINARY=${1:?Usage: verify-pe-target.sh BINARY [REPORT]}
+REPORT=${2:-hello-world-architecture.json}
+TARGET_TRIPLET=${TARGET_TRIPLET:-aarch64-w64-mingw32}
+COMPILER=${CC:-${TARGET_TRIPLET}-gcc}
+OBJDUMP=${OBJDUMP:-${TARGET_TRIPLET}-objdump}
+
+ACTUAL_TARGET=$("$COMPILER" -dumpmachine)
+if [[ "$ACTUAL_TARGET" != "$TARGET_TRIPLET" ]]; then
+  echo "Compiler target mismatch: expected $TARGET_TRIPLET, got $ACTUAL_TARGET" >&2
+  exit 1
+fi
+
+DOS_MAGIC=$(od -An -tx1 -N2 "$BINARY" | tr -d '[:space:]')
+if [[ "$DOS_MAGIC" != "4d5a" ]]; then
+  echo "$BINARY is not a PE image: missing MZ header" >&2
+  exit 1
+fi
+
+PE_OFFSET_BYTES=($(od -An -tx1 -j60 -N4 "$BINARY"))
+if [[ ${#PE_OFFSET_BYTES[@]} -ne 4 ]]; then
+  echo "Unable to read the PE header offset from $BINARY" >&2
+  exit 1
+fi
+
+PE_OFFSET=$((0x${PE_OFFSET_BYTES[0]} |
+  (0x${PE_OFFSET_BYTES[1]} << 8) |
+  (0x${PE_OFFSET_BYTES[2]} << 16) |
+  (0x${PE_OFFSET_BYTES[3]} << 24)))
+PE_SIGNATURE=$(od -An -tx1 -j"$PE_OFFSET" -N4 "$BINARY" | tr -d '[:space:]')
+if [[ "$PE_SIGNATURE" != "50450000" ]]; then
+  echo "$BINARY is not a PE image: invalid PE signature" >&2
+  exit 1
+fi
+
+MACHINE_BYTES=$(od -An -tx1 -j"$((PE_OFFSET + 4))" -N2 "$BINARY" | tr -d '[:space:]')
+if [[ "$MACHINE_BYTES" != "64aa" ]]; then
+  echo "$BINARY has PE machine bytes $MACHINE_BYTES; expected 64aa (ARM64)" >&2
+  exit 1
+fi
+
+OBJDUMP_OUTPUT=$("$OBJDUMP" -f "$BINARY")
+echo "$OBJDUMP_OUTPUT"
+if ! grep -q "file format pei-aarch64-little" <<< "$OBJDUMP_OUTPUT"; then
+  echo "$OBJDUMP did not identify $BINARY as pei-aarch64-little" >&2
+  exit 1
+fi
+
+cat > "$REPORT" <<EOF
+{
+  "schema_version": 1,
+  "verified": true,
+  "file": "$(basename "$BINARY")",
+  "format": "PE",
+  "machine": "IMAGE_FILE_MACHINE_ARM64",
+  "machine_hex": "0xaa64",
+  "compiler": "$COMPILER",
+  "compiler_target": "$ACTUAL_TARGET",
+  "objdump_format": "pei-aarch64-little"
+}
+EOF

--- a/.github/workflows/check-repository.yml
+++ b/.github/workflows/check-repository.yml
@@ -44,7 +44,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: hello-world-cross
-          path: hello-world.exe
+          path: |
+            hello-world.exe
+            hello-world-architecture.json
 
   test-cross:
     needs: [build-cross]
@@ -112,7 +114,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: hello-world-native
-          path: hello-world.exe
+          path: |
+            hello-world.exe
+            hello-world-architecture.json
          
   test-native:
     needs: [build-native]

--- a/.github/workflows/mingw-cross-toolchain.yml
+++ b/.github/workflows/mingw-cross-toolchain.yml
@@ -32,6 +32,7 @@ jobs:
     with:
       package_name: mingw-w64-cross-mingwarm64-binutils
       needs: ${{ toJson(needs) }}
+      dependencies: texinfo
       packages_repository: Windows-on-ARM-Experiments/MSYS2-packages
       packages_branch: ${{ inputs.msys2_packages_branch || 'woarm64' }}
 

--- a/.github/workflows/mingw-cross-toolchain.yml
+++ b/.github/workflows/mingw-cross-toolchain.yml
@@ -212,7 +212,8 @@ jobs:
         run: |
           python3 .github/scripts/create-bootstrap-status.py \
             --output bootstrap-status/bootstrap-status.json \
-            --target aarch64-w64-mingw32 \
+            --mingw-target aarch64-w64-mingw32 \
+            --runtime-target aarch64-pc-cygwin \
             --packages-repository Windows-on-ARM-Experiments/MSYS2-packages \
             --packages-ref '${{ inputs.msys2_packages_branch || 'woarm64' }}' \
             --run-repository '${{ github.repository }}' \

--- a/.github/workflows/mingw-cross-toolchain.yml
+++ b/.github/workflows/mingw-cross-toolchain.yml
@@ -119,3 +119,123 @@ jobs:
       needs: ${{ toJson(needs) }}
       packages_repository: Windows-on-ARM-Experiments/MSYS2-packages
       packages_branch: ${{ inputs.msys2_packages_branch || 'woarm64' }}
+
+  verify-cross-toolchain:
+    name: Verify aarch64-w64-mingw32 PE output
+    needs: [
+      mingw-w64-cross-mingwarm64-headers,
+      mingw-w64-cross-mingwarm64-binutils,
+      mingw-w64-cross-mingwarm64-gcc-stage1,
+      mingw-w64-cross-mingwarm64-windows-default-manifest,
+      mingw-w64-cross-mingwarm64-crt,
+      mingw-w64-cross-mingwarm64-winpthreads,
+      mingw-w64-cross-mingwarm64-gcc,
+      mingw-w64-cross-mingwarm64-zlib
+    ]
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    env:
+      FLAVOR: CROSS
+
+    steps:
+      - uses: msys2/setup-msys2@v2
+        timeout-minutes: 10
+        with:
+          msystem: MSYS
+          path-type: minimal
+          update: true
+          cache: true
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download cross-toolchain packages
+        uses: actions/download-artifact@v4
+        with:
+          pattern: mingw-w64-cross-mingwarm64-*
+          merge-multiple: true
+          path: artifacts
+
+      - name: Install completed cross toolchain
+        run: |
+          rm -f artifacts/*gcc-stage1*.pkg.tar.zst
+          pacman -U --noconfirm artifacts/*.pkg.tar.zst
+          mkdir -p verification
+
+      - name: Build and inspect ARM64 PE smoke binary
+        working-directory: verification
+        run: |
+          `cygpath "${{ github.workspace }}"`/.github/scripts/build-hello-world.sh
+
+      - name: Upload architecture evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: verify-cross-toolchain
+          retention-days: 14
+          path: |
+            verification/hello-world.exe
+            verification/hello-world-architecture.json
+
+  mingw-cross-bootstrap-status:
+    if: ${{ always() }}
+    name: Publish cross-toolchain bootstrap status
+    needs: [
+      mingw-w64-cross-mingwarm64-headers,
+      mingw-w64-cross-mingwarm64-binutils,
+      mingw-w64-cross-mingwarm64-gcc-stage1,
+      mingw-w64-cross-mingwarm64-windows-default-manifest,
+      mingw-w64-cross-mingwarm64-crt,
+      mingw-w64-cross-mingwarm64-winpthreads,
+      mingw-w64-cross-mingwarm64-gcc,
+      mingw-w64-cross-mingwarm64-zlib,
+      verify-cross-toolchain
+    ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download architecture evidence
+        if: needs.verify-cross-toolchain.result == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          name: verify-cross-toolchain
+          path: bootstrap-status
+
+      - name: Create bootstrap status manifest
+        run: |
+          python3 .github/scripts/create-bootstrap-status.py \
+            --output bootstrap-status/bootstrap-status.json \
+            --target aarch64-w64-mingw32 \
+            --packages-repository Windows-on-ARM-Experiments/MSYS2-packages \
+            --packages-ref '${{ inputs.msys2_packages_branch || 'woarm64' }}' \
+            --run-repository '${{ github.repository }}' \
+            --run-id '${{ github.run_id }}' \
+            --run-attempt '${{ github.run_attempt }}' \
+            --run-sha '${{ github.sha }}' \
+            --run-ref '${{ github.ref }}' \
+            --run-url '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}' \
+            --package 'mingw-w64-cross-mingwarm64-headers=${{ needs.mingw-w64-cross-mingwarm64-headers.result }}' \
+            --package 'mingw-w64-cross-mingwarm64-binutils=${{ needs.mingw-w64-cross-mingwarm64-binutils.result }}' \
+            --package 'mingw-w64-cross-mingwarm64-gcc-stage1=${{ needs.mingw-w64-cross-mingwarm64-gcc-stage1.result }}' \
+            --package 'mingw-w64-cross-mingwarm64-windows-default-manifest=${{ needs.mingw-w64-cross-mingwarm64-windows-default-manifest.result }}' \
+            --package 'mingw-w64-cross-mingwarm64-crt=${{ needs.mingw-w64-cross-mingwarm64-crt.result }}' \
+            --package 'mingw-w64-cross-mingwarm64-winpthreads=${{ needs.mingw-w64-cross-mingwarm64-winpthreads.result }}' \
+            --package 'mingw-w64-cross-mingwarm64-gcc=${{ needs.mingw-w64-cross-mingwarm64-gcc.result }}' \
+            --package 'mingw-w64-cross-mingwarm64-zlib=${{ needs.mingw-w64-cross-mingwarm64-zlib.result }}' \
+            --verification 'verify-cross-toolchain=${{ needs.verify-cross-toolchain.result }}' \
+            --architecture-report bootstrap-status/hello-world-architecture.json
+
+          python3 -c "import json; report=json.load(open('bootstrap-status/bootstrap-status.json')); print(f\"### Cross-toolchain bootstrap\n\n- Status: {report['status']}\n- First failure: {report['first_failure'] or 'none'}\")" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload cross-toolchain bootstrap status
+        uses: actions/upload-artifact@v4
+        with:
+          name: mingw-cross-bootstrap-status
+          retention-days: 30
+          path: bootstrap-status/bootstrap-status.json

--- a/README.md
+++ b/README.md
@@ -161,6 +161,15 @@ flowchart LR
     end
 ```
 
+Every cross-toolchain run publishes two machine-readable artifacts:
+
+- `verify-cross-toolchain` contains the smoke-test executable and
+  `hello-world-architecture.json`, which records the compiler target and verifies the PE
+  `IMAGE_FILE_MACHINE_ARM64` header.
+- `mingw-cross-bootstrap-status` contains `bootstrap-status.json`, an ordered component status
+  manifest with `first_failure` set to the first package or architecture check that failed. The
+  manifest is uploaded even when downstream bootstrap jobs are skipped.
+
 ## MinGW Native Toolchain CI
 
 The [mingw-native-toolchain.yml](https://github.com/Windows-on-ARM-Experiments/msys2-woarm64-build/blob/main/.github/workflows/mingw-native-toolchain.yml)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MSYS2 WoArm64 Packages Build and Repository
 
 This repository contains GitHub Actions workflows for building MinGW and MSYS2 toolchains
-with `aarch64-w64-mingw32` and `aarch64-pc-msys` targets inside MSYS2 environment and deploys
+with `aarch64-w64-mingw32` and `aarch64-pc-cygwin` targets inside MSYS2 environment and deploys
 their Pacman packages overlay repositories to GitHub Pages environment of this repository.
 It also serves as a documentation of the necessary steps to build them.
 
@@ -168,7 +168,9 @@ Every cross-toolchain run publishes two machine-readable artifacts:
   `IMAGE_FILE_MACHINE_ARM64` header.
 - `mingw-cross-bootstrap-status` contains `bootstrap-status.json`, an ordered component status
   manifest with `first_failure` set to the first package or architecture check that failed. The
-  manifest is uploaded even when downstream bootstrap jobs are skipped.
+  manifest is uploaded even when downstream bootstrap jobs are skipped. Its `targets` object
+  distinguishes the `aarch64-w64-mingw32` MinGW target from the `aarch64-pc-cygwin` runtime
+  build triplet.
 
 ## MinGW Native Toolchain CI
 
@@ -302,10 +304,11 @@ flowchart LR
 
 ## MSYS2/Cygwin Toolchain Porting
 
-Work on native `aarch64-pc-msys`, resp. `aarch64-pc-cygwin`, toolchain is in progress.
-First iteration taken is to provide `x86_64-pc-msys` host, `aarch64-pc-msys` target cross-toolchain
-that will then eventually build the `aarch64-pc-msys` native toolchain. The current status of the
-cross-toolchain can be visualized by the following chart:
+Work on the native MSYS2 ARM64 toolchain is in progress. Runtime configury uses the
+`aarch64-pc-cygwin` build triplet; MSYS behavior is selected by the runtime sources. The first
+iteration provides an `x86_64-pc-msys` host, `aarch64-pc-cygwin` target cross-toolchain that will
+eventually build the native MSYS2 ARM64 environment. The current status of the cross-toolchain can
+be visualized by the following chart:
 
 ```mermaid
 %%{init: {"flowchart": {"htmlLabels": false, 'nodeSpacing': 30, 'rankSpacing': 30}} }%%
@@ -327,7 +330,7 @@ flowchart LR
     msys2-runtime-devel["`
         msys2-runtime-devel
         host: x86_64-pc-msys
-        target: aarch64-pc-msys
+        target: aarch64-pc-cygwin
     `"]:::DONE
     
     mingw-w64-cross-mingwarm64-gcc["`
@@ -359,19 +362,19 @@ flowchart LR
     cross-binutils["`
         cross-binutils
         host: x86_64-pc-msys
-        target: aarch64-pc-msys
+        target: aarch64-pc-cygwin
     `"]:::NEW_DONE
 
     cross-gcc-stage1["`
         cross-gcc-stage1
         host: x86_64-pc-msys
-        target: aarch64-pc-msys
+        target: aarch64-pc-cygwin
     `"]:::NEW_DONE
 
     cross-gcc["`
         cross-gcc
         host: x86_64-pc-msys
-        target: aarch64-pc-msys
+        target: aarch64-pc-cygwin
     `"]:::NEW_WIP
 
     windows-default-manifest["`
@@ -433,7 +436,7 @@ flowchart LR
 
 ## Detailed MSYS2 Toolchian Packages Dependencies Chart
 
-Relevant for `x86-64-pc-msys` host, `aarch64-pc-msys` and `aarch64-w64-mingw32`  target 
+Relevant for `x86-64-pc-msys` host, `aarch64-pc-cygwin` and `aarch64-w64-mingw32` target
 cross-compilation option:
 
 ```mermaid
@@ -468,7 +471,7 @@ flowchart LR
     msys2-runtime-devel["`
         msys2-runtime-devel
         host: x86_64-pc-msys
-        target: aarch64-pc-msys
+        target: aarch64-pc-cygwin
     `"]:::DONE
 
     mingw-w64-cross-mingwarm64-binutils["`
@@ -527,19 +530,19 @@ flowchart LR
     cross-binutils["`
         cross-binutils
         host: x86_64-pc-msys
-        target: aarch64-pc-msys
+        target: aarch64-pc-cygwin
     `"]:::NEW_DONE
 
     cross-gcc-stage1["`
         cross-gcc-stage1
         host: x86_64-pc-msys
-        target: aarch64-pc-msys
+        target: aarch64-pc-cygwin
     `"]:::NEW_DONE
 
     cross-gcc["`
         cross-gcc
         host: x86_64-pc-msys
-        target: aarch64-pc-msys
+        target: aarch64-pc-cygwin
     `"]:::NEW_WIP
 
     windows-default-manifest["`


### PR DESCRIPTION
## Summary
- carry the `pthread_compat.h` dependency required by current winpthreads into the temporary CRT bootstrap header set, incorporating #22
- restore the current binutils build by installing `texinfo` explicitly instead of hiding `makeinfo` behind the ccache wrapper path
- install completed cross packages, compile a smoke executable, and verify both `-dumpmachine` and the PE `IMAGE_FILE_MACHINE_ARM64` header
- always publish `mingw-cross-bootstrap-status/bootstrap-status.json` with ordered component results and the first failing component
- distinguish the `aarch64-w64-mingw32` MinGW target from the `aarch64-pc-cygwin` runtime build triplet in schema v2 and the porting documentation

## Validation
Focused workflow run: https://github.com/crutkas/msys2-woarm64-build/actions/runs/31723630578

- headers, binutils, GCC stage 1, manifest, CRT, and winpthreads all built successfully against current MSYS2
- binutils passed after the explicit `texinfo` fix
- the always-run status job succeeded and its artifact reported `mingw-w64-cross-mingwarm64-gcc` as `first_failure`
- GCC reached packaging before failing on the external recipe's stale `libgcc_s.a` path
- locally parsed the changed workflow YAML, ran Bash syntax checks, exercised successful and failing schema-v2 manifests, accepted a synthetic ARM64 PE fixture, and rejected the equivalent x64 fixture

## External blockers
- `Windows-on-ARM-Experiments/MSYS2-packages` currently assumes `/opt/lib/gcc/aarch64-w64-mingw32/lib/libgcc_s.a` exists; GCC 15 no longer installs it there, so the recipe fails while packaging. This repository should not guess the replacement layout.
- a runtime compile consumer is not added here: this workflow produces `aarch64-w64-mingw32-gcc`, while `msys2/msys2-runtime#359` requires `aarch64-pc-cygwin-gcc`. The status manifest now names both targets so consumers cannot accidentally use the MinGW compiler for the runtime probe.

Related to #21.